### PR TITLE
docs: add direct SSH access documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ morph instance exec <instance-id> <command>
 # SSH into instance
 morph instance ssh <instance-id> [command]
 
+# Direct SSH access
+You can also SSH directly into a MorphVM instance using the following format:
+```bash
+ssh {instance-id}@ssh.cloud.morph.so
+```
+This provides a convenient way to access your instances without using the CLI.
+
 # Port forwarding
 morph instance port-forward <instance-id> <remote-port> [local-port]
 


### PR DESCRIPTION
Add documentation for direct SSH access to MorphVM instances using the format `ssh {instance-id}@ssh.cloud.morph.so`.

This provides users with information about a convenient way to access their instances without using the CLI.