### PR TITLE
Add from_snapshot_id static method to Snapshot class

### DIFF
--- a/morphcloud/experimental/__init__.py
+++ b/morphcloud/experimental/__init__.py
@@ -295,6 +295,11 @@ class Snapshot:
                                        digest=name, metadata={"name": name})
         return cls(snap)
 
+    @staticmethod
+    def from_snapshot_id(snapshot_id: str) -> "Snapshot":
+        snap = client.snapshots.get(snapshot_id)
+        return Snapshot(snap)
+
     @contextmanager
     def start(self):
         with client.instances.start(snapshot_id=self.snapshot.id, metadata=dict(root=self.snapshot.id)) as inst:


### PR DESCRIPTION
## Summary
- Added `from_snapshot_id` static method to the `Snapshot` class in `morphcloud.experimental`
- The method takes a `snapshot_id` string parameter and returns a `Snapshot` instance
- Uses `client.snapshots.get()` to retrieve the snapshot from the API

## Implementation Details
- Method is implemented as a static method following Python conventions
- Returns a new `Snapshot` instance wrapping the retrieved snapshot
- Follows the existing code patterns in the class

## Test plan
- [x] Code compiles and imports successfully
- [ ] Manual testing with actual snapshot IDs (requires live environment)
- [ ] Integration with existing snapshot workflows

🤖 Generated with [Claude Code](https://claude.ai/code)