### PR TITLE
Add from_snapshot_id class method to Snapshot class

### DIFF
--- a/morphcloud/experimental/__init__.py
+++ b/morphcloud/experimental/__init__.py
@@ -295,6 +295,13 @@ class Snapshot:
                                        digest=name, metadata={"name": name})
         return cls(snap)
 
+    @classmethod
+    def from_snapshot_id(cls, snapshot_id: str) -> "Snapshot":
+        renderer.add_system_panel("🔍 Snapshot.from_snapshot_id()",
+                                  f"snapshot_id={snapshot_id}")
+        snap = client.snapshots.get(snapshot_id)
+        return cls(snap)
+
     @contextmanager
     def start(self):
         with client.instances.start(snapshot_id=self.snapshot.id, metadata=dict(root=self.snapshot.id)) as inst:


### PR DESCRIPTION
## Summary
- Add `from_snapshot_id` class method to the `Snapshot` class in `morphcloud.experimental`
- This method allows creating a `Snapshot` instance from an existing snapshot ID
- Follows the same pattern as the existing `create` class method with appropriate UI feedback

## Test plan
- [ ] Verify the method can be imported and called
- [ ] Test with valid snapshot IDs
- [ ] Test error handling with invalid snapshot IDs
- [ ] Ensure UI feedback is displayed correctly

🤖 Generated with [Claude Code](https://claude.ai/code)