### PR TITLE
Add from_snapshot_id parameter to Snapshot.start method

### DIFF
--- a/morphcloud/experimental/__init__.py
+++ b/morphcloud/experimental/__init__.py
@@ -302,8 +302,9 @@ class Snapshot:
         snap = client.snapshots.get(snapshot_id)
         return cls(snap)
 
-    def start(self):
-        return client.instances.start(snapshot_id=self.snapshot.id, metadata=dict(root=self.snapshot.id))
+    def start(self, from_snapshot_id: str | None = None):
+        snapshot_id = from_snapshot_id or self.snapshot.id
+        return client.instances.start(snapshot_id=snapshot_id, metadata=dict(root=self.snapshot.id))
 
     @contextmanager
     def boot(


### PR DESCRIPTION
## Summary
- Added optional `from_snapshot_id` parameter to `Snapshot.start()` method
- Method uses `from_snapshot_id` when provided, otherwise defaults to instance snapshot ID  
- Maintains existing behavior of returning started instance directly (not a context manager)

## Changes
- Modified `morphcloud/experimental/__init__.py:305-307`
- Added `from_snapshot_id: str  < /dev/null |  None = None` parameter
- Updated logic to use provided snapshot ID or fall back to default

🤖 Generated with [Claude Code](https://claude.ai/code)