### PR TITLE
Modify Snapshot.start() to return non-context-manager instance

### DIFF
--- a/morphcloud/experimental/__init__.py
+++ b/morphcloud/experimental/__init__.py
@@ -303,7 +303,16 @@ class Snapshot:
         return cls(snap)
 
     def start(self):
-        return client.instances.start(snapshot_id=self.snapshot.id, metadata=dict(root=self.snapshot.id))
+        instance = client.instances.start(snapshot_id=self.snapshot.id, metadata=dict(root=self.snapshot.id))
+        # Return a wrapper that disables context manager behavior
+        class InstanceWrapper:
+            def __init__(self, instance):
+                self._instance = instance
+            
+            def __getattr__(self, name):
+                return getattr(self._instance, name)
+        
+        return InstanceWrapper(instance)
 
     @contextmanager
     def boot(
@@ -519,12 +528,15 @@ class Snapshot:
                 style=f"on {PALETTE['bg']}",
             )
         )
-        with self.start() as instance:
+        instance = self.start()
+        try:
             url = instance.expose_http_service(name=name, port=port)
             renderer.console.print(
                 f"[{_colour('success')}]Started service at {url}[/]"
             )
             yield instance, url
+        finally:
+            instance.stop()
 
     def tag(self, tag: str):
         renderer.console.print(


### PR DESCRIPTION
## Summary
- Modified `Snapshot.start()` to return an instance that is not a context manager
- Created `InstanceWrapper` class to disable context manager behavior (`__enter__`/`__exit__` methods)
- Updated `deploy()` method to handle the non-context-manager instance with explicit try/finally for cleanup
- Users can now call `.start()` and manage instance lifecycle manually without being forced into context manager pattern

## Changes
- `Snapshot.start()` now returns `InstanceWrapper` instead of raw `Instance`
- `InstanceWrapper` proxies all methods/attributes to the underlying `Instance` but removes context manager functionality
- `deploy()` method updated to use try/finally pattern for proper cleanup

## Test plan
- [ ] Verify `.start()` method returns started instance
- [ ] Verify returned instance cannot be used as context manager
- [ ] Verify all instance methods still work through the wrapper
- [ ] Verify deploy() method still works correctly
- [ ] Test manual instance lifecycle management

🤖 Generated with [Claude Code](https://claude.ai/code)