### PR TITLE
Add .id property to morphcloud.experimental.Snapshot class

### DIFF
--- a/morphcloud/experimental/__init__.py
+++ b/morphcloud/experimental/__init__.py
@@ -278,6 +278,11 @@ class Snapshot:
     def __init__(self, snapshot: _Snapshot):
         self.snapshot = snapshot
 
+    @property
+    def id(self) -> str:
+        """Return the ID of the inner snapshot."""
+        return self.snapshot.id
+
     @classmethod
     def create(cls, name: str, image_id: str = "morphvm-minimal",
                vcpus: int = 1, memory: int = 4096, disk_size: int = 8192,


### PR DESCRIPTION
## Summary
- Add `.id` property to `morphcloud.experimental.Snapshot` class that returns the ID of the inner snapshot
- Provides convenient access to snapshot ID without requiring direct access to internal `snapshot` attribute

## Implementation Details
- Added `@property` decorator with proper type annotation (`-> str`)
- Returns `self.snapshot.id` from the underlying API snapshot object
- Follows existing patterns in the codebase for accessing inner snapshot properties

## Test plan
- [ ] Verify that `morphcloud.experimental.Snapshot` instances now have an accessible `.id` property
- [ ] Confirm the property returns the correct string ID from the inner snapshot
- [ ] Test that existing functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)