### PR TITLE
feat(cli,api): add paginated list + interactive -i for snapshots/instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ venv/
 # Environment variables
 .env
 .env.*
+.envrc
 
 # Testing
 .coverage


### PR DESCRIPTION
API: add list_paginated for snapshots (/snapshot/list) and instances (/instance/list). CLI: add -i interactive mode with arrow-key pagination and scrolling, mirroring admin /users UX. Backwards-compatible; existing list output unchanged.