### PR TITLE
Use sharded httpx transports by default

### DIFF
--- a/morphcloud/_http_transport.py
+++ b/morphcloud/_http_transport.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import asyncio
+import itertools
+import os
+import typing
+
+import httpx
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    if value is None or value == "":
+        return default
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    value = os.environ.get(name)
+    if value is None or value == "":
+        return default
+    try:
+        return float(value)
+    except Exception:
+        return default
+
+
+class ShardedTransport(httpx.BaseTransport):
+    def __init__(self, transports: typing.Sequence[httpx.HTTPTransport]) -> None:
+        self._transports = list(transports)
+        self._counter = itertools.count()
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        transport = self._transports[next(self._counter) % len(self._transports)]
+        return transport.handle_request(request)
+
+    def close(self) -> None:
+        for transport in self._transports:
+            transport.close()
+
+
+class ShardedAsyncTransport(httpx.AsyncBaseTransport):
+    def __init__(
+        self, transports: typing.Sequence[httpx.AsyncHTTPTransport]
+    ) -> None:
+        self._transports = list(transports)
+        self._counter = itertools.count()
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        transport = self._transports[next(self._counter) % len(self._transports)]
+        return await transport.handle_async_request(request)
+
+    async def aclose(self) -> None:
+        await asyncio.gather(*(transport.aclose() for transport in self._transports))
+
+
+def _new_limits() -> httpx.Limits:
+    max_connections = _env_int("MORPH_HTTP_MAX_CONNECTIONS", 100)
+    max_keepalive_connections = _env_int(
+        "MORPH_HTTP_MAX_KEEPALIVE_CONNECTIONS",
+        max_connections,
+    )
+    keepalive_expiry = _env_float("MORPH_HTTP_KEEPALIVE_EXPIRY", 60.0)
+    return httpx.Limits(
+        max_connections=max_connections,
+        max_keepalive_connections=max_keepalive_connections,
+        keepalive_expiry=keepalive_expiry,
+    )
+
+
+def build_http_transport() -> httpx.BaseTransport:
+    # Spread requests across independent httpcore pools to avoid contention
+    # in a single transport under high concurrency. Set to 1 to disable.
+    transport_shards = max(_env_int("MORPH_HTTP_TRANSPORT_SHARDS", 16), 1)
+    if transport_shards == 1:
+        return httpx.HTTPTransport(limits=_new_limits())
+    return ShardedTransport(
+        [httpx.HTTPTransport(limits=_new_limits()) for _ in range(transport_shards)]
+    )
+
+
+def build_async_http_transport() -> httpx.AsyncBaseTransport:
+    transport_shards = max(_env_int("MORPH_HTTP_TRANSPORT_SHARDS", 16), 1)
+    if transport_shards == 1:
+        return httpx.AsyncHTTPTransport(limits=_new_limits())
+    return ShardedAsyncTransport(
+        [
+            httpx.AsyncHTTPTransport(limits=_new_limits())
+            for _ in range(transport_shards)
+        ]
+    )

--- a/morphcloud/api.py
+++ b/morphcloud/api.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel, Field, PrivateAttr
 # Import Rich for fancy printing
 from rich.console import Console
 
+from morphcloud._http_transport import build_async_http_transport, build_http_transport
 from morphcloud._utils import StrEnum
 from morphcloud.config import resolve_settings
 
@@ -194,27 +195,12 @@ class MorphCloudClient:
             except Exception:
                 return default
 
-        # Defaults tuned for moderate concurrency without excessive TLS connection churn.
-        # Override via env vars if you need to constrain socket usage.
-        max_connections = _env_int("MORPH_HTTP_MAX_CONNECTIONS", 100)
-        max_keepalive_connections = _env_int(
-            "MORPH_HTTP_MAX_KEEPALIVE_CONNECTIONS",
-            max_connections,
-        )
-        keepalive_expiry = _env_float("MORPH_HTTP_KEEPALIVE_EXPIRY", 60.0)
-
         # Always retry once on transient transport errors for instance.exec/instance.aexec.
         # Use `MORPH_EXEC_RETRY_BACKOFF_S` to tune the (small) backoff.
         self._exec_retries = 1
         self._exec_retry_backoff_s = _env_float("MORPH_EXEC_RETRY_BACKOFF_S", 0.05)
-
-        limits = httpx.Limits(
-            max_connections=max_connections,
-            max_keepalive_connections=max_keepalive_connections,
-            keepalive_expiry=keepalive_expiry,
-        )
-        transport = httpx.HTTPTransport(limits=limits)
-        async_transport = httpx.AsyncHTTPTransport(limits=limits)
+        transport = build_http_transport()
+        async_transport = build_async_http_transport()
 
         self._http_client = ApiClient(
             base_url=self.base_url,

--- a/morphcloud/devbox/gen/client.py
+++ b/morphcloud/devbox/gen/client.py
@@ -4,6 +4,8 @@ import typing
 
 import httpx
 
+from morphcloud._http_transport import build_async_http_transport, build_http_transport
+
 from .admin.client import AdminClient, AsyncAdminClient
 from .aliases.client import AliasesClient, AsyncAliasesClient
 from .core.client_wrapper import AsyncClientWrapper, SyncClientWrapper
@@ -75,10 +77,15 @@ class MorphLabsApi:
                 if httpx_client is not None
                 else (
                     httpx.Client(
-                        timeout=_defaulted_timeout, follow_redirects=follow_redirects
+                        timeout=_defaulted_timeout,
+                        follow_redirects=follow_redirects,
+                        transport=build_http_transport(),
                     )
                     if follow_redirects is not None
-                    else httpx.Client(timeout=_defaulted_timeout)
+                    else httpx.Client(
+                        timeout=_defaulted_timeout,
+                        transport=build_http_transport(),
+                    )
                 )
             ),
             timeout=_defaulted_timeout,
@@ -154,10 +161,15 @@ class AsyncMorphLabsApi:
                 if httpx_client is not None
                 else (
                     httpx.AsyncClient(
-                        timeout=_defaulted_timeout, follow_redirects=follow_redirects
+                        timeout=_defaulted_timeout,
+                        follow_redirects=follow_redirects,
+                        transport=build_async_http_transport(),
                     )
                     if follow_redirects is not None
-                    else httpx.AsyncClient(timeout=_defaulted_timeout)
+                    else httpx.AsyncClient(
+                        timeout=_defaulted_timeout,
+                        transport=build_async_http_transport(),
+                    )
                 )
             ),
             timeout=_defaulted_timeout,

--- a/tests/unit/test_http_transport_sharding.py
+++ b/tests/unit/test_http_transport_sharding.py
@@ -1,0 +1,93 @@
+import asyncio
+
+from morphcloud._http_transport import ShardedAsyncTransport, ShardedTransport
+from morphcloud.api import MorphCloudClient
+from morphcloud.devbox.client import AsyncDevboxClient, DevboxClient
+
+
+def _make_client(monkeypatch, shards=None):
+    monkeypatch.setenv("MORPH_API_KEY", "test-key")
+    if shards is None:
+        monkeypatch.delenv("MORPH_HTTP_TRANSPORT_SHARDS", raising=False)
+    else:
+        monkeypatch.setenv("MORPH_HTTP_TRANSPORT_SHARDS", str(shards))
+    monkeypatch.setattr(MorphCloudClient, "_load_sdk_plugins", lambda self: None)
+    return MorphCloudClient(base_url="https://cloud.morph.so/api")
+
+
+def _make_devbox_clients(monkeypatch, shards=None):
+    monkeypatch.setenv("MORPH_API_KEY", "test-key")
+    if shards is None:
+        monkeypatch.delenv("MORPH_HTTP_TRANSPORT_SHARDS", raising=False)
+    else:
+        monkeypatch.setenv("MORPH_HTTP_TRANSPORT_SHARDS", str(shards))
+    return (
+        DevboxClient(base_url="https://devbox.svc.cloud.morph.so", token="test-key"),
+        AsyncDevboxClient(
+            base_url="https://devbox.svc.cloud.morph.so", token="test-key"
+        ),
+    )
+
+
+def test_client_uses_sharded_transports_by_default(monkeypatch):
+    client = _make_client(monkeypatch)
+    try:
+        assert isinstance(client._http_client._transport, ShardedTransport)
+        assert isinstance(client._async_http_client._transport, ShardedAsyncTransport)
+        assert len(client._http_client._transport._transports) == 16
+        assert len(client._async_http_client._transport._transports) == 16
+    finally:
+        client._http_client.close()
+        asyncio.run(client._async_http_client.aclose())
+
+
+def test_transport_shards_can_be_disabled(monkeypatch):
+    client = _make_client(monkeypatch, shards=1)
+    try:
+        assert not isinstance(client._http_client._transport, ShardedTransport)
+        assert not isinstance(client._async_http_client._transport, ShardedAsyncTransport)
+    finally:
+        client._http_client.close()
+        asyncio.run(client._async_http_client.aclose())
+
+
+def test_devbox_clients_use_sharded_transports_by_default(monkeypatch):
+    client, async_client = _make_devbox_clients(monkeypatch)
+    try:
+        assert isinstance(
+            client._client_wrapper.httpx_client.httpx_client._transport,
+            ShardedTransport,
+        )
+        assert isinstance(
+            async_client._client_wrapper.httpx_client.httpx_client._transport,
+            ShardedAsyncTransport,
+        )
+        assert (
+            len(client._client_wrapper.httpx_client.httpx_client._transport._transports)
+            == 16
+        )
+        assert (
+            len(
+                async_client._client_wrapper.httpx_client.httpx_client._transport._transports
+            )
+            == 16
+        )
+    finally:
+        client._client_wrapper.httpx_client.httpx_client.close()
+        asyncio.run(async_client._client_wrapper.httpx_client.httpx_client.aclose())
+
+
+def test_devbox_transport_shards_can_be_disabled(monkeypatch):
+    client, async_client = _make_devbox_clients(monkeypatch, shards=1)
+    try:
+        assert not isinstance(
+            client._client_wrapper.httpx_client.httpx_client._transport,
+            ShardedTransport,
+        )
+        assert not isinstance(
+            async_client._client_wrapper.httpx_client.httpx_client._transport,
+            ShardedAsyncTransport,
+        )
+    finally:
+        client._client_wrapper.httpx_client.httpx_client.close()
+        asyncio.run(async_client._client_wrapper.httpx_client.httpx_client.aclose())


### PR DESCRIPTION
## Summary
- add a shared internal transport builder that shards SDK traffic across multiple independent `httpx` transports
- use that transport by default in both `MorphCloudClient` and the devbox client so the behavior applies across the package
- default to `MORPH_HTTP_TRANSPORT_SHARDS=16`, with `MORPH_HTTP_TRANSPORT_SHARDS=1` as the escape hatch to disable sharding
- add unit coverage for the main client and devbox client defaults

## Why
Under high concurrency, increasing `httpx` pool sizes on a single client did not reproduce the behavior we saw from splitting work across multiple clients. Sharding one client's traffic across multiple underlying transports did.

On the `64 instances x 32 execs = 2048 execs` workload:
- single client, default transport: `p50 44.04s`, `p99 82.25s`, `0` timeouts
- single client, sharded transport with `16` shards: `p50 10.48s`, `p99 18.96s`, `0` timeouts
- `64` shards slightly tightened the tail but introduced timeouts, so `16` looked like the safer default

## Verification
- `uv run --group dev pytest tests/unit/test_http_transport_sharding.py`
- `uv run --group dev pytest tests/unit`
