### PR TITLE
Add snapshot TTL support to the Python SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,8 @@ print("done\n")
 
 ### Snapshot TTL
 
+`ttl_seconds` must be greater than zero when you set it. Use `None` in Python or `--ttl-seconds -1` in the CLI to remove an existing snapshot TTL.
+
 ```python
 from morphcloud.api import MorphCloudClient
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ morphcloud image list [--json]
 morphcloud snapshot list [--json] [--metadata KEY=VALUE]
 
 # Create a new snapshot
-morphcloud snapshot create --image-id <id> --vcpus <n> --memory <mb> --disk-size <mb> [--digest <hash>] [--metadata KEY=VALUE]
+morphcloud snapshot create --image-id <id> --vcpus <n> --memory <mb> --disk-size <mb> [--digest <hash>] [--ttl-seconds <seconds>] [--metadata KEY=VALUE]
 
 # Get detailed snapshot information
 morphcloud snapshot get <snapshot-id>
@@ -112,6 +112,9 @@ morphcloud snapshot delete <snapshot-id>
 
 # Set metadata on a snapshot
 morphcloud snapshot set-metadata <snapshot-id> KEY1=VALUE1 [KEY2=VALUE2...]
+
+# Set or clear snapshot retention
+morphcloud snapshot set-ttl <snapshot-id> --ttl-seconds <seconds|-1>
 ```
 
 ### Instances
@@ -139,7 +142,7 @@ morphcloud instance stop <instance-id>
 morphcloud instance get <instance-id>
 
 # Create snapshot from instance
-morphcloud instance snapshot <instance-id> [--digest <hash>] [--json]
+morphcloud instance snapshot <instance-id> [--digest <hash>] [--ttl-seconds <seconds>] [--json]
 
 # Create multiple instances from an instance (branching)
 morphcloud instance branch <instance-id> [--count <n>] [--json]
@@ -363,6 +366,46 @@ print("done")
 print("Stopping the instance...............", end="")
 instance.stop()
 print("done\n")
+```
+
+### Snapshot TTL
+
+```python
+from morphcloud.api import MorphCloudClient
+
+client = MorphCloudClient()
+
+snapshot = client.snapshots.create(
+    image_id="morphvm-minimal",
+    vcpus=1,
+    memory=512,
+    disk_size=1024,
+    ttl_seconds=3600,  # auto-delete after 1 hour of inactivity
+)
+
+print(snapshot.ttl.ttl_seconds)
+print(snapshot.ttl.ttl_expire_at)
+
+# Update an existing snapshot TTL
+snapshot.set_ttl(7200)
+
+# Clear the snapshot TTL entirely
+snapshot.set_ttl(None)
+```
+
+CLI equivalents:
+
+```bash
+morphcloud snapshot create \
+  --image-id morphvm-minimal \
+  --vcpus 1 \
+  --memory 512 \
+  --disk-size 1024 \
+  --ttl-seconds 3600
+
+morphcloud snapshot set-ttl snapshot_123 --ttl-seconds 7200
+morphcloud snapshot set-ttl snapshot_123 --ttl-seconds -1
+morphcloud instance snapshot instance_123 --ttl-seconds 3600
 ```
 
 ### Working with SSH

--- a/morphcloud/api.py
+++ b/morphcloud/api.py
@@ -120,6 +120,18 @@ class SnapshotTTL(BaseModel):
     )
 
 
+def _validate_snapshot_ttl_seconds(
+    ttl_seconds: typing.Optional[int], *, allow_none: bool
+) -> None:
+    """Validate snapshot TTL values before sending them to the API."""
+    if ttl_seconds is None:
+        if allow_none:
+            return
+        raise ValueError("ttl_seconds must be greater than zero")
+    if ttl_seconds <= 0:
+        raise ValueError("ttl_seconds must be greater than zero")
+
+
 class WakeOn(BaseModel):
     """Represents the wake-on-event configuration for an instance."""
 
@@ -668,6 +680,8 @@ class SnapshotAPI:
             digest: Optional digest for the snapshot. If provided, it will be used to identify the snapshot. If a snapshot with the same digest already exists, it will be returned instead of creating a new one.
             metadata: Optional metadata to attach to the snapshot.
             ttl_seconds: Optional retention period in seconds before the snapshot is automatically deleted."""
+        if ttl_seconds is not None:
+            _validate_snapshot_ttl_seconds(ttl_seconds, allow_none=False)
         body = {}
         if image_id is not None:
             body["image_id"] = image_id
@@ -708,6 +722,8 @@ class SnapshotAPI:
             digest: Optional digest for the snapshot. If provided, it will be used to identify the snapshot. If a snapshot with the same digest already exists, it will be returned instead of creating a new one.
             metadata: Optional metadata to attach to the snapshot.
             ttl_seconds: Optional retention period in seconds before the snapshot is automatically deleted."""
+        if ttl_seconds is not None:
+            _validate_snapshot_ttl_seconds(ttl_seconds, allow_none=False)
         body = {}
         if image_id is not None:
             body["image_id"] = image_id
@@ -797,6 +813,7 @@ class Snapshot(BaseModel):
         Parameters:
             ttl_seconds: New TTL in seconds. Pass None to remove the snapshot TTL.
         """
+        _validate_snapshot_ttl_seconds(ttl_seconds, allow_none=True)
         response = self._api._client._http_client.post(
             f"/snapshot/{self.id}/ttl", json={"ttl_seconds": ttl_seconds}
         )
@@ -805,6 +822,7 @@ class Snapshot(BaseModel):
 
     async def aset_ttl(self, ttl_seconds: typing.Optional[int]) -> None:
         """Async version of set_ttl()."""
+        _validate_snapshot_ttl_seconds(ttl_seconds, allow_none=True)
         response = await self._api._client._async_http_client.post(
             f"/snapshot/{self.id}/ttl", json={"ttl_seconds": ttl_seconds}
         )
@@ -2818,6 +2836,8 @@ class Instance(BaseModel):
             metadata: Optional metadata to attach to the new snapshot.
             ttl_seconds: Optional retention period in seconds before the snapshot is automatically deleted.
         """
+        if ttl_seconds is not None:
+            _validate_snapshot_ttl_seconds(ttl_seconds, allow_none=False)
         params = {}
         if digest is not None:
             params["digest"] = digest
@@ -2840,6 +2860,8 @@ class Instance(BaseModel):
         ttl_seconds: typing.Optional[int] = None,
     ) -> Snapshot:
         """Async version of snapshot()."""
+        if ttl_seconds is not None:
+            _validate_snapshot_ttl_seconds(ttl_seconds, allow_none=False)
         params = {}
         if digest is not None:
             params = {"digest": digest}

--- a/morphcloud/api.py
+++ b/morphcloud/api.py
@@ -109,6 +109,17 @@ class TTL(BaseModel):
     )
 
 
+class SnapshotTTL(BaseModel):
+    """Represents the retention policy for a snapshot."""
+
+    ttl_seconds: typing.Optional[int] = Field(
+        None, description="Time in seconds until the snapshot expires."
+    )
+    ttl_expire_at: typing.Optional[int] = Field(
+        None, description="Unix timestamp when the snapshot is set to expire."
+    )
+
+
 class WakeOn(BaseModel):
     """Represents the wake-on-event configuration for an instance."""
 
@@ -645,6 +656,7 @@ class SnapshotAPI:
         disk_size: typing.Optional[int] = None,
         digest: typing.Optional[str] = None,
         metadata: typing.Optional[typing.Dict[str, str]] = None,
+        ttl_seconds: typing.Optional[int] = None,
     ) -> Snapshot:
         """Create a new snapshot from a base image and a machine configuration.
 
@@ -654,7 +666,8 @@ class SnapshotAPI:
             memory: The amount of memory (in MB) for the snapshot.
             disk_size: The size of the snapshot (in MB).
             digest: Optional digest for the snapshot. If provided, it will be used to identify the snapshot. If a snapshot with the same digest already exists, it will be returned instead of creating a new one.
-            metadata: Optional metadata to attach to the snapshot."""
+            metadata: Optional metadata to attach to the snapshot.
+            ttl_seconds: Optional retention period in seconds before the snapshot is automatically deleted."""
         body = {}
         if image_id is not None:
             body["image_id"] = image_id
@@ -668,6 +681,8 @@ class SnapshotAPI:
             body["digest"] = digest
         if metadata is not None:
             body["metadata"] = metadata
+        if ttl_seconds is not None:
+            body["ttl_seconds"] = ttl_seconds
         response = self._client._http_client.post("/snapshot", json=body)
         snap: Snapshot = Snapshot.model_validate(response.json())._set_api(self)
         snap.wait_until_ready()
@@ -681,6 +696,7 @@ class SnapshotAPI:
         disk_size: typing.Optional[int] = None,
         digest: typing.Optional[str] = None,
         metadata: typing.Optional[typing.Dict[str, str]] = None,
+        ttl_seconds: typing.Optional[int] = None,
     ) -> Snapshot:
         """Create a new snapshot from a base image and a machine configuration.
 
@@ -690,7 +706,8 @@ class SnapshotAPI:
             memory: The amount of memory (in MB) for the snapshot.
             disk_size: The size of the snapshot (in MB).
             digest: Optional digest for the snapshot. If provided, it will be used to identify the snapshot. If a snapshot with the same digest already exists, it will be returned instead of creating a new one.
-            metadata: Optional metadata to attach to the snapshot."""
+            metadata: Optional metadata to attach to the snapshot.
+            ttl_seconds: Optional retention period in seconds before the snapshot is automatically deleted."""
         body = {}
         if image_id is not None:
             body["image_id"] = image_id
@@ -704,6 +721,8 @@ class SnapshotAPI:
             body["digest"] = digest
         if metadata is not None:
             body["metadata"] = metadata
+        if ttl_seconds is not None:
+            body["ttl_seconds"] = ttl_seconds
         response = await self._client._async_http_client.post("/snapshot", json=body)
         snap: Snapshot = Snapshot.model_validate(response.json())._set_api(self)
         await snap.await_until_ready()
@@ -735,6 +754,7 @@ class Snapshot(BaseModel):
     metadata: typing.Dict[str, str] = Field(
         default_factory=dict, description="User provided metadata"
     )
+    ttl: SnapshotTTL = Field(default_factory=SnapshotTTL)
 
     _api: SnapshotAPI = PrivateAttr()
 
@@ -767,6 +787,26 @@ class Snapshot(BaseModel):
     async def aset_metadata(self, metadata: typing.Dict[str, str]) -> None:
         response = await self._api._client._async_http_client.post(
             f"/snapshot/{self.id}/metadata", json=metadata
+        )
+        response.raise_for_status()
+        await self._refresh_async()
+
+    def set_ttl(self, ttl_seconds: typing.Optional[int]) -> None:
+        """Set or clear the retention policy for this snapshot.
+
+        Parameters:
+            ttl_seconds: New TTL in seconds. Pass None to remove the snapshot TTL.
+        """
+        response = self._api._client._http_client.post(
+            f"/snapshot/{self.id}/ttl", json={"ttl_seconds": ttl_seconds}
+        )
+        response.raise_for_status()
+        self._refresh()
+
+    async def aset_ttl(self, ttl_seconds: typing.Optional[int]) -> None:
+        """Async version of set_ttl()."""
+        response = await self._api._client._async_http_client.post(
+            f"/snapshot/{self.id}/ttl", json={"ttl_seconds": ttl_seconds}
         )
         response.raise_for_status()
         await self._refresh_async()
@@ -2769,13 +2809,25 @@ class Instance(BaseModel):
         self,
         digest: typing.Optional[str] = None,
         metadata: typing.Optional[typing.Dict[str, str]] = None,
+        ttl_seconds: typing.Optional[int] = None,
     ) -> Snapshot:
-        """Save the instance as a snapshot."""
+        """Save the instance as a snapshot.
+
+        Parameters:
+            digest: Optional digest to associate with the new snapshot.
+            metadata: Optional metadata to attach to the new snapshot.
+            ttl_seconds: Optional retention period in seconds before the snapshot is automatically deleted.
+        """
         params = {}
         if digest is not None:
             params["digest"] = digest
+        body: typing.Dict[str, typing.Any] = {}
+        if metadata is not None:
+            body["metadata"] = metadata
+        if ttl_seconds is not None:
+            body["ttl_seconds"] = ttl_seconds
         response = self._api._client._http_client.post(
-            f"/instance/{self.id}/snapshot", params=params, json=dict(metadata=metadata)
+            f"/instance/{self.id}/snapshot", params=params, json=body
         )
         return Snapshot.model_validate(response.json())._set_api(
             self._api._client.snapshots,
@@ -2785,13 +2837,19 @@ class Instance(BaseModel):
         self,
         digest: typing.Optional[str] = None,
         metadata: typing.Optional[typing.Dict[str, str]] = None,
+        ttl_seconds: typing.Optional[int] = None,
     ) -> Snapshot:
-        """Save the instance as a snapshot."""
+        """Async version of snapshot()."""
         params = {}
         if digest is not None:
             params = {"digest": digest}
+        body: typing.Dict[str, typing.Any] = {}
+        if metadata is not None:
+            body["metadata"] = metadata
+        if ttl_seconds is not None:
+            body["ttl_seconds"] = ttl_seconds
         response = await self._api._client._async_http_client.post(
-            f"/instance/{self.id}/snapshot", params=params, json=dict(metadata=metadata)
+            f"/instance/{self.id}/snapshot", params=params, json=body
         )
         return Snapshot.model_validate(response.json())._set_api(
             self._api._client.snapshots

--- a/morphcloud/cli.py
+++ b/morphcloud/cli.py
@@ -1001,9 +1001,15 @@ def list_snapshots(metadata, interactive, page, limit, json_mode):
 
             def format_item(snap):
                 created = unix_timestamp_to_datetime(snap.created)
+                ttl_seconds = (
+                    str(snap.ttl.ttl_seconds)
+                    if snap.ttl.ttl_seconds is not None
+                    else "-"
+                )
                 return (
                     f"   📸 {snap.id:<24} | {created:<22} | "
-                    f"{snap.status:<8} | vCPU {snap.spec.vcpus:<2} | Mem {snap.spec.memory:<6} | Disk {snap.spec.disk_size:<6} | img {snap.refs.image_id}"
+                    f"{snap.status:<8} | TTL {ttl_seconds:<6} | "
+                    f"vCPU {snap.spec.vcpus:<2} | Mem {snap.spec.memory:<6} | Disk {snap.spec.disk_size:<6} | img {snap.refs.image_id}"
                 )
 
             def on_search():
@@ -1066,6 +1072,7 @@ def list_snapshots(metadata, interactive, page, limit, json_mode):
                 "ID",
                 "Created At",
                 "Status",
+                "TTL (s)",
                 "VCPUs",
                 "Memory (MB)",
                 "Disk Size (MB)",
@@ -1078,6 +1085,7 @@ def list_snapshots(metadata, interactive, page, limit, json_mode):
                         snap.id,
                         unix_timestamp_to_datetime(snap.created),
                         snap.status,
+                        snap.ttl.ttl_seconds if snap.ttl.ttl_seconds is not None else "",
                         snap.spec.vcpus,
                         snap.spec.memory,
                         snap.spec.disk_size,
@@ -1098,6 +1106,12 @@ def list_snapshots(metadata, interactive, page, limit, json_mode):
 )
 @click.option("--digest", help="Optional unique digest for caching/identification.")
 @click.option(
+    "--ttl-seconds",
+    type=int,
+    required=False,
+    help="Optional snapshot retention period in seconds.",
+)
+@click.option(
     "--metadata",
     "-m",
     "metadata_options",
@@ -1108,7 +1122,14 @@ def list_snapshots(metadata, interactive, page, limit, json_mode):
     "--json", "json_mode", is_flag=True, default=False, help="Output result as JSON."
 )
 def create_snapshot(
-    image_id, vcpus, memory, disk_size, digest, metadata_options, json_mode
+    image_id,
+    vcpus,
+    memory,
+    disk_size,
+    digest,
+    ttl_seconds,
+    metadata_options,
+    json_mode,
 ):
     """Create a new snapshot from a base image and specifications."""
     client = get_client()
@@ -1131,6 +1152,7 @@ def create_snapshot(
                 memory=memory,
                 disk_size=disk_size,
                 digest=digest,
+                ttl_seconds=ttl_seconds,
                 metadata=metadata_dict if metadata_dict else None,
             )
 
@@ -1140,6 +1162,8 @@ def create_snapshot(
             click.secho(f"Snapshot created: {new_snapshot.id}", fg="green")
             if new_snapshot.digest:
                 click.echo(f"Digest: {new_snapshot.digest}")
+            if new_snapshot.ttl.ttl_seconds is not None:
+                click.echo(f"TTL: {new_snapshot.ttl.ttl_seconds} seconds")
     except Exception as e:
         handle_api_error(e)
 
@@ -1226,6 +1250,52 @@ def set_snapshot_metadata(snapshot_id, metadata, metadata_args):
 
         updated = client.snapshots.get(snapshot_id)
         click.echo(format_json(updated))
+    except api.ApiError as e:
+        if e.status_code == 404:
+            click.echo(f"Error: Snapshot '{snapshot_id}' not found.", err=True)
+            sys.exit(1)
+        else:
+            handle_api_error(e)
+    except Exception as e:
+        handle_api_error(e)
+
+
+@snapshot.command("set-ttl")
+@click.argument("snapshot_id")
+@click.option(
+    "--ttl-seconds",
+    type=int,
+    required=True,
+    help="Snapshot TTL in seconds. Use -1 to remove TTL.",
+)
+def set_snapshot_ttl(snapshot_id, ttl_seconds):
+    """Set or remove a time-to-live (TTL) for a snapshot."""
+    client = get_client()
+    try:
+        snapshot_obj = client.snapshots.get(snapshot_id)
+
+        removing = ttl_seconds == -1
+        spinner_text = (
+            f"Removing TTL for {snapshot_id}..."
+            if removing
+            else f"Setting TTL for {snapshot_id} to {ttl_seconds} seconds..."
+        )
+        success_text = (
+            "Snapshot TTL removed successfully!"
+            if removing
+            else "Snapshot TTL set successfully!"
+        )
+        with Spinner(
+            text=spinner_text,
+            success_text=success_text,
+            success_emoji="⏳",
+        ):
+            snapshot_obj.set_ttl(None if removing else ttl_seconds)
+
+        if removing:
+            click.echo(f"TTL removed for {snapshot_id}")
+        else:
+            click.echo(f"TTL set for {snapshot_id}: {ttl_seconds} seconds")
     except api.ApiError as e:
         if e.status_code == 404:
             click.echo(f"Error: Snapshot '{snapshot_id}' not found.", err=True)
@@ -1626,6 +1696,12 @@ def get_instance(instance_id):
 @click.argument("instance_id")
 @click.option("--digest", help="Optional unique digest.")
 @click.option(
+    "--ttl-seconds",
+    type=int,
+    required=False,
+    help="Optional snapshot retention period in seconds.",
+)
+@click.option(
     "--metadata",
     "-m",
     help="Metadata to attach (format: key=value)",
@@ -1634,7 +1710,7 @@ def get_instance(instance_id):
 @click.option(
     "--json", "json_mode", is_flag=True, default=False, help="Output result as JSON."
 )
-def snapshot_instance(instance_id, digest, metadata, json_mode):
+def snapshot_instance(instance_id, digest, ttl_seconds, metadata, json_mode):
     """Create a new snapshot from an instance."""
     client = get_client()
 
@@ -1665,7 +1741,11 @@ def snapshot_instance(instance_id, digest, metadata, json_mode):
             success_text="Instance snapshot complete!",
             success_emoji="📸",
         ):
-            new_snapshot = instance_obj.snapshot(digest=digest, metadata=metadata_dict)
+            new_snapshot = instance_obj.snapshot(
+                digest=digest,
+                metadata=metadata_dict,
+                ttl_seconds=ttl_seconds,
+            )
 
         if json_mode:
             click.echo(format_json(new_snapshot))
@@ -1673,6 +1753,8 @@ def snapshot_instance(instance_id, digest, metadata, json_mode):
             click.secho(f"Snapshot created: {new_snapshot.id}", fg="green")
             if new_snapshot.digest:
                 click.echo(f"Digest: {new_snapshot.digest}")
+            if new_snapshot.ttl.ttl_seconds is not None:
+                click.echo(f"TTL: {new_snapshot.ttl.ttl_seconds} seconds")
     except api.ApiError as e:
         if e.status_code == 404:
             click.echo(f"Error: Instance '{instance_id}' not found.", err=True)

--- a/morphcloud/cli.py
+++ b/morphcloud/cli.py
@@ -212,6 +212,22 @@ def unix_timestamp_to_datetime(timestamp):
             return "Invalid Timestamp"
 
 
+def _validate_positive_snapshot_ttl(ctx, param, value):
+    if value is None:
+        return value
+    if value <= 0:
+        raise click.BadParameter("must be greater than 0")
+    return value
+
+
+def _validate_snapshot_ttl_or_clear(ctx, param, value):
+    if value is None:
+        return value
+    if value == -1 or value > 0:
+        return value
+    raise click.BadParameter("must be greater than 0, or -1 to clear")
+
+
 # ─────────────────────────────────────────────────────────────
 #  Profiles
 # ─────────────────────────────────────────────────────────────
@@ -1110,6 +1126,7 @@ def list_snapshots(metadata, interactive, page, limit, json_mode):
     type=int,
     required=False,
     help="Optional snapshot retention period in seconds.",
+    callback=_validate_positive_snapshot_ttl,
 )
 @click.option(
     "--metadata",
@@ -1267,6 +1284,7 @@ def set_snapshot_metadata(snapshot_id, metadata, metadata_args):
     type=int,
     required=True,
     help="Snapshot TTL in seconds. Use -1 to remove TTL.",
+    callback=_validate_snapshot_ttl_or_clear,
 )
 def set_snapshot_ttl(snapshot_id, ttl_seconds):
     """Set or remove a time-to-live (TTL) for a snapshot."""
@@ -1700,6 +1718,7 @@ def get_instance(instance_id):
     type=int,
     required=False,
     help="Optional snapshot retention period in seconds.",
+    callback=_validate_positive_snapshot_ttl,
 )
 @click.option(
     "--metadata",
@@ -1726,12 +1745,9 @@ def snapshot_instance(instance_id, digest, ttl_seconds, metadata, json_mode):
 
     try:
         instance_obj = client.instances.get(instance_id)
-        if instance_obj.status not in [
-            api.InstanceStatus.READY,
-            api.InstanceStatus.PAUSED,
-        ]:
+        if instance_obj.status != api.InstanceStatus.READY:
             click.echo(
-                f"Error: Instance must be READY or PAUSED. Current: {instance_obj.status.value}",
+                f"Error: Instance must be READY. Current: {instance_obj.status.value}",
                 err=True,
             )
             sys.exit(1)

--- a/tests/integration/test_snapshot_operations.py
+++ b/tests/integration/test_snapshot_operations.py
@@ -240,6 +240,49 @@ async def test_snapshot_metadata(client, base_image):
                 logger.error(f"Error deleting snapshot: {e}")
 
 
+async def test_snapshot_ttl(client, base_image):
+    """Test creating, updating, and clearing snapshot TTL."""
+    logger.info("Testing snapshot TTL")
+
+    try:
+        snapshot = await client.snapshots.acreate(
+            image_id=base_image.id,
+            vcpus=1,
+            memory=512,
+            disk_size=8192,
+            ttl_seconds=120,
+        )
+        logger.info(f"Created snapshot with TTL: {snapshot.id}")
+
+        assert snapshot.ttl.ttl_seconds == 120
+        assert snapshot.ttl.ttl_expire_at is not None
+
+        await snapshot.aset_ttl(240)
+        assert snapshot.ttl.ttl_seconds == 240
+        assert snapshot.ttl.ttl_expire_at is not None
+
+        refreshed_snapshot = await client.snapshots.aget(snapshot.id)
+        assert refreshed_snapshot.ttl.ttl_seconds == 240
+
+        await snapshot.aset_ttl(None)
+        assert snapshot.ttl.ttl_seconds is None
+        assert snapshot.ttl.ttl_expire_at is None
+
+        refreshed_snapshot = await client.snapshots.aget(snapshot.id)
+        assert refreshed_snapshot.ttl.ttl_seconds is None
+
+        logger.info("Snapshot TTL test completed successfully")
+
+    finally:
+        if 'snapshot' in locals():
+            try:
+                logger.info(f"Deleting snapshot {snapshot.id}")
+                await snapshot.adelete()
+                logger.info("Snapshot deleted")
+            except Exception as e:
+                logger.error(f"Error deleting snapshot: {e}")
+
+
 async def test_snapshot_multiple_instances(client, base_image):
     """Test starting multiple instances from the same snapshot."""
     logger.info("Testing starting multiple instances from the same snapshot")

--- a/tests/unit/test_cli_snapshots.py
+++ b/tests/unit/test_cli_snapshots.py
@@ -73,6 +73,43 @@ def test_snapshot_create_passes_ttl_seconds(monkeypatch):
     assert "TTL: 60 seconds" in result.output
 
 
+def test_snapshot_create_rejects_non_positive_ttl(monkeypatch):
+    import morphcloud.cli as cli_mod
+
+    create_calls = []
+
+    class StubSnapshots:
+        def create(self, **kwargs):
+            create_calls.append(kwargs)
+            return types.SimpleNamespace(id="snapshot_123", digest=None, ttl=None)
+
+    stub_client = types.SimpleNamespace(snapshots=StubSnapshots())
+    monkeypatch.setattr(cli_mod, "get_client", lambda: stub_client)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_mod.cli,
+        [
+            "snapshot",
+            "create",
+            "--image-id",
+            "morphvm-minimal",
+            "--vcpus",
+            "1",
+            "--memory",
+            "512",
+            "--disk-size",
+            "1024",
+            "--ttl-seconds",
+            "0",
+        ],
+    )
+
+    assert result.exit_code == 2, result.output
+    assert "Invalid value for '--ttl-seconds'" in result.output
+    assert create_calls == []
+
+
 def test_snapshot_set_ttl_uses_none_to_clear(monkeypatch):
     import morphcloud.cli as cli_mod
 
@@ -101,6 +138,34 @@ def test_snapshot_set_ttl_uses_none_to_clear(monkeypatch):
     assert result.exit_code == 0, result.output
     assert set_ttl_calls == [None]
     assert "TTL removed for snapshot_123" in result.output
+
+
+def test_snapshot_set_ttl_rejects_invalid_negative_values(monkeypatch):
+    import morphcloud.cli as cli_mod
+
+    set_ttl_calls = []
+
+    class StubSnapshot:
+        def set_ttl(self, ttl_seconds):
+            set_ttl_calls.append(ttl_seconds)
+
+    class StubSnapshots:
+        def get(self, snapshot_id):
+            assert snapshot_id == "snapshot_123"
+            return StubSnapshot()
+
+    stub_client = types.SimpleNamespace(snapshots=StubSnapshots())
+    monkeypatch.setattr(cli_mod, "get_client", lambda: stub_client)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_mod.cli,
+        ["snapshot", "set-ttl", "snapshot_123", "--ttl-seconds", "-2"],
+    )
+
+    assert result.exit_code == 2, result.output
+    assert "Invalid value for '--ttl-seconds'" in result.output
+    assert set_ttl_calls == []
 
 
 def test_instance_snapshot_passes_ttl_seconds(monkeypatch):
@@ -155,6 +220,69 @@ def test_instance_snapshot_passes_ttl_seconds(monkeypatch):
         }
     ]
     assert "TTL: 45 seconds" in result.output
+
+
+def test_instance_snapshot_rejects_non_positive_ttl(monkeypatch):
+    import morphcloud.cli as cli_mod
+
+    snapshot_calls = []
+
+    class StubInstance:
+        status = "ready"
+
+        def snapshot(self, **kwargs):
+            snapshot_calls.append(kwargs)
+            return types.SimpleNamespace(id="snapshot_123", digest=None, ttl=None)
+
+    class StubInstances:
+        def get(self, instance_id):
+            assert instance_id == "instance_123"
+            return StubInstance()
+
+    stub_client = types.SimpleNamespace(instances=StubInstances())
+    monkeypatch.setattr(cli_mod, "get_client", lambda: stub_client)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_mod.cli,
+        ["instance", "snapshot", "instance_123", "--ttl-seconds", "0"],
+    )
+
+    assert result.exit_code == 2, result.output
+    assert "Invalid value for '--ttl-seconds'" in result.output
+    assert snapshot_calls == []
+
+
+def test_instance_snapshot_requires_ready_instance(monkeypatch):
+    import morphcloud.api as api_mod
+    import morphcloud.cli as cli_mod
+
+    snapshot_calls = []
+
+    class StubInstance:
+        status = api_mod.InstanceStatus.PAUSED
+
+        def snapshot(self, **kwargs):
+            snapshot_calls.append(kwargs)
+            return types.SimpleNamespace(id="snapshot_123", digest=None, ttl=None)
+
+    class StubInstances:
+        def get(self, instance_id):
+            assert instance_id == "instance_123"
+            return StubInstance()
+
+    stub_client = types.SimpleNamespace(instances=StubInstances())
+    monkeypatch.setattr(cli_mod, "get_client", lambda: stub_client)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_mod.cli,
+        ["instance", "snapshot", "instance_123"],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert "Instance must be READY. Current: paused" in result.output
+    assert snapshot_calls == []
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_cli_snapshots.py
+++ b/tests/unit/test_cli_snapshots.py
@@ -1,0 +1,179 @@
+import types
+
+import pytest
+from click.testing import CliRunner
+
+
+def _install_noop_spinner(monkeypatch):
+    import morphcloud.cli as cli_mod
+
+    class NoopSpinner:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(cli_mod, "Spinner", NoopSpinner)
+
+
+def test_snapshot_create_passes_ttl_seconds(monkeypatch):
+    import morphcloud.cli as cli_mod
+
+    _install_noop_spinner(monkeypatch)
+
+    create_calls = []
+
+    class StubSnapshots:
+        def create(self, **kwargs):
+            create_calls.append(kwargs)
+            return types.SimpleNamespace(
+                id="snapshot_123",
+                digest=None,
+                ttl=types.SimpleNamespace(ttl_seconds=kwargs.get("ttl_seconds")),
+            )
+
+    stub_client = types.SimpleNamespace(snapshots=StubSnapshots())
+    monkeypatch.setattr(cli_mod, "get_client", lambda: stub_client)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_mod.cli,
+        [
+            "snapshot",
+            "create",
+            "--image-id",
+            "morphvm-minimal",
+            "--vcpus",
+            "1",
+            "--memory",
+            "512",
+            "--disk-size",
+            "1024",
+            "--ttl-seconds",
+            "60",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert create_calls == [
+        {
+            "image_id": "morphvm-minimal",
+            "vcpus": 1,
+            "memory": 512,
+            "disk_size": 1024,
+            "digest": None,
+            "ttl_seconds": 60,
+            "metadata": None,
+        }
+    ]
+    assert "TTL: 60 seconds" in result.output
+
+
+def test_snapshot_set_ttl_uses_none_to_clear(monkeypatch):
+    import morphcloud.cli as cli_mod
+
+    _install_noop_spinner(monkeypatch)
+
+    set_ttl_calls = []
+
+    class StubSnapshot:
+        def set_ttl(self, ttl_seconds):
+            set_ttl_calls.append(ttl_seconds)
+
+    class StubSnapshots:
+        def get(self, snapshot_id):
+            assert snapshot_id == "snapshot_123"
+            return StubSnapshot()
+
+    stub_client = types.SimpleNamespace(snapshots=StubSnapshots())
+    monkeypatch.setattr(cli_mod, "get_client", lambda: stub_client)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_mod.cli,
+        ["snapshot", "set-ttl", "snapshot_123", "--ttl-seconds", "-1"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert set_ttl_calls == [None]
+    assert "TTL removed for snapshot_123" in result.output
+
+
+def test_instance_snapshot_passes_ttl_seconds(monkeypatch):
+    import morphcloud.api as api_mod
+    import morphcloud.cli as cli_mod
+
+    _install_noop_spinner(monkeypatch)
+
+    snapshot_calls = []
+
+    class StubInstance:
+        status = api_mod.InstanceStatus.READY
+
+        def snapshot(self, **kwargs):
+            snapshot_calls.append(kwargs)
+            return types.SimpleNamespace(
+                id="snapshot_123",
+                digest=kwargs.get("digest"),
+                ttl=types.SimpleNamespace(ttl_seconds=kwargs.get("ttl_seconds")),
+            )
+
+    class StubInstances:
+        def get(self, instance_id):
+            assert instance_id == "instance_123"
+            return StubInstance()
+
+    stub_client = types.SimpleNamespace(instances=StubInstances())
+    monkeypatch.setattr(cli_mod, "get_client", lambda: stub_client)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_mod.cli,
+        [
+            "instance",
+            "snapshot",
+            "instance_123",
+            "--digest",
+            "digest-1",
+            "--ttl-seconds",
+            "45",
+            "--metadata",
+            "env=test",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert snapshot_calls == [
+        {
+            "digest": "digest-1",
+            "metadata": {"env": "test"},
+            "ttl_seconds": 45,
+        }
+    ]
+    assert "TTL: 45 seconds" in result.output
+
+
+@pytest.mark.parametrize(
+    ("argv", "needle"),
+    [
+        (
+            ["snapshot", "create", "--help"],
+            "--ttl-seconds",
+        ),
+        (
+            ["snapshot", "set-ttl", "--help"],
+            "Snapshot TTL in seconds",
+        ),
+    ],
+)
+def test_snapshot_cli_help_mentions_ttl(monkeypatch, argv, needle):
+    import morphcloud.cli as cli_mod
+
+    runner = CliRunner()
+    result = runner.invoke(cli_mod.cli, argv)
+    assert result.exit_code == 0, result.output
+    assert needle in result.output

--- a/tests/unit/test_snapshot_ttl.py
+++ b/tests/unit/test_snapshot_ttl.py
@@ -1,0 +1,210 @@
+import types
+
+import pytest
+
+from morphcloud.api import Instance, Snapshot, SnapshotAPI
+
+
+class StubResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        return None
+
+
+class StubHTTPClient:
+    def __init__(self, payload):
+        self.payload = payload
+        self.post_calls = []
+
+    def post(self, url, params=None, json=None):
+        self.post_calls.append(
+            {
+                "url": url,
+                "params": params,
+                "json": json,
+            }
+        )
+        return StubResponse(self.payload)
+
+
+class StubAsyncHTTPClient:
+    def __init__(self, payload):
+        self.payload = payload
+        self.post_calls = []
+
+    async def post(self, url, params=None, json=None):
+        self.post_calls.append(
+            {
+                "url": url,
+                "params": params,
+                "json": json,
+            }
+        )
+        return StubResponse(self.payload)
+
+
+class StubSnapshotAPI:
+    def __init__(self, http_payload, refresh_payload):
+        self._http_client = StubHTTPClient(http_payload)
+        self._async_http_client = StubAsyncHTTPClient(http_payload)
+        self._client = types.SimpleNamespace(
+            _http_client=self._http_client,
+            _async_http_client=self._async_http_client,
+        )
+        self._refresh_payload = refresh_payload
+
+    def get(self, snapshot_id):
+        assert snapshot_id == self._refresh_payload["id"]
+        return Snapshot.model_validate(self._refresh_payload)._set_api(self)
+
+    async def aget(self, snapshot_id):
+        assert snapshot_id == self._refresh_payload["id"]
+        return Snapshot.model_validate(self._refresh_payload)._set_api(self)
+
+
+def _snapshot_payload(*, ttl_seconds=None, ttl_expire_at=None):
+    payload = {
+        "id": "snapshot_123",
+        "object": "snapshot",
+        "created": 1,
+        "status": "ready",
+        "spec": {"vcpus": 1, "memory": 512, "disk_size": 1024},
+        "refs": {"image_id": "morphvm-minimal"},
+        "metadata": {},
+    }
+    if ttl_seconds is not None or ttl_expire_at is not None:
+        payload["ttl"] = {
+            "ttl_seconds": ttl_seconds,
+            "ttl_expire_at": ttl_expire_at,
+        }
+    return payload
+
+
+def _instance_payload():
+    return {
+        "id": "instance_123",
+        "object": "instance",
+        "created": 1,
+        "status": "ready",
+        "spec": {"vcpus": 1, "memory": 512, "disk_size": 1024},
+        "refs": {
+            "snapshot_id": "snapshot_base",
+            "image_id": "morphvm-minimal",
+        },
+        "networking": {"internal_ip": None, "http_services": []},
+        "metadata": {},
+    }
+
+
+def test_snapshot_model_parses_ttl():
+    snapshot = Snapshot.model_validate(
+        _snapshot_payload(ttl_seconds=60, ttl_expire_at=120)
+    )
+
+    assert snapshot.ttl.ttl_seconds == 60
+    assert snapshot.ttl.ttl_expire_at == 120
+
+
+def test_snapshot_create_sends_ttl_seconds():
+    http_client = StubHTTPClient(_snapshot_payload(ttl_seconds=60, ttl_expire_at=120))
+    client = types.SimpleNamespace(_http_client=http_client)
+
+    snapshot = SnapshotAPI(client).create(
+        image_id="morphvm-minimal",
+        vcpus=1,
+        memory=512,
+        disk_size=1024,
+        ttl_seconds=60,
+    )
+
+    assert http_client.post_calls == [
+        {
+            "url": "/snapshot",
+            "params": None,
+            "json": {
+                "image_id": "morphvm-minimal",
+                "vcpus": 1,
+                "memory": 512,
+                "disk_size": 1024,
+                "ttl_seconds": 60,
+            },
+        }
+    ]
+    assert snapshot.ttl.ttl_seconds == 60
+
+
+def test_instance_snapshot_sends_ttl_seconds():
+    http_client = StubHTTPClient(_snapshot_payload(ttl_seconds=45, ttl_expire_at=90))
+    client = types.SimpleNamespace(
+        _http_client=http_client,
+        snapshots=types.SimpleNamespace(),
+    )
+    instance = Instance.model_validate(_instance_payload())._set_api(
+        types.SimpleNamespace(_client=client)
+    )
+
+    snapshot = instance.snapshot(
+        digest="digest-1",
+        metadata={"env": "test"},
+        ttl_seconds=45,
+    )
+
+    assert http_client.post_calls == [
+        {
+            "url": "/instance/instance_123/snapshot",
+            "params": {"digest": "digest-1"},
+            "json": {
+                "metadata": {"env": "test"},
+                "ttl_seconds": 45,
+            },
+        }
+    ]
+    assert snapshot.ttl.ttl_seconds == 45
+
+
+def test_snapshot_set_ttl_can_clear_snapshot_ttl():
+    api = StubSnapshotAPI(
+        http_payload=_snapshot_payload(ttl_seconds=60, ttl_expire_at=120),
+        refresh_payload=_snapshot_payload(ttl_seconds=None, ttl_expire_at=None),
+    )
+    snapshot = Snapshot.model_validate(
+        _snapshot_payload(ttl_seconds=60, ttl_expire_at=120)
+    )._set_api(api)
+
+    snapshot.set_ttl(None)
+
+    assert api._http_client.post_calls == [
+        {
+            "url": "/snapshot/snapshot_123/ttl",
+            "params": None,
+            "json": {"ttl_seconds": None},
+        }
+    ]
+    assert snapshot.ttl.ttl_seconds is None
+    assert snapshot.ttl.ttl_expire_at is None
+
+
+@pytest.mark.asyncio
+async def test_snapshot_aset_ttl_updates_snapshot():
+    api = StubSnapshotAPI(
+        http_payload=_snapshot_payload(ttl_seconds=120, ttl_expire_at=240),
+        refresh_payload=_snapshot_payload(ttl_seconds=120, ttl_expire_at=240),
+    )
+    snapshot = Snapshot.model_validate(_snapshot_payload())._set_api(api)
+
+    await snapshot.aset_ttl(120)
+
+    assert api._async_http_client.post_calls == [
+        {
+            "url": "/snapshot/snapshot_123/ttl",
+            "params": None,
+            "json": {"ttl_seconds": 120},
+        }
+    ]
+    assert snapshot.ttl.ttl_seconds == 120
+    assert snapshot.ttl.ttl_expire_at == 240

--- a/tests/unit/test_snapshot_ttl.py
+++ b/tests/unit/test_snapshot_ttl.py
@@ -138,6 +138,23 @@ def test_snapshot_create_sends_ttl_seconds():
     assert snapshot.ttl.ttl_seconds == 60
 
 
+@pytest.mark.parametrize("ttl_seconds", [0, -5])
+def test_snapshot_create_rejects_non_positive_ttl(ttl_seconds):
+    http_client = StubHTTPClient(_snapshot_payload())
+    client = types.SimpleNamespace(_http_client=http_client)
+
+    with pytest.raises(ValueError, match="ttl_seconds must be greater than zero"):
+        SnapshotAPI(client).create(
+            image_id="morphvm-minimal",
+            vcpus=1,
+            memory=512,
+            disk_size=1024,
+            ttl_seconds=ttl_seconds,
+        )
+
+    assert http_client.post_calls == []
+
+
 def test_instance_snapshot_sends_ttl_seconds():
     http_client = StubHTTPClient(_snapshot_payload(ttl_seconds=45, ttl_expire_at=90))
     client = types.SimpleNamespace(
@@ -167,6 +184,23 @@ def test_instance_snapshot_sends_ttl_seconds():
     assert snapshot.ttl.ttl_seconds == 45
 
 
+@pytest.mark.parametrize("ttl_seconds", [0, -1])
+def test_instance_snapshot_rejects_non_positive_ttl(ttl_seconds):
+    http_client = StubHTTPClient(_snapshot_payload())
+    client = types.SimpleNamespace(
+        _http_client=http_client,
+        snapshots=types.SimpleNamespace(),
+    )
+    instance = Instance.model_validate(_instance_payload())._set_api(
+        types.SimpleNamespace(_client=client)
+    )
+
+    with pytest.raises(ValueError, match="ttl_seconds must be greater than zero"):
+        instance.snapshot(ttl_seconds=ttl_seconds)
+
+    assert http_client.post_calls == []
+
+
 def test_snapshot_set_ttl_can_clear_snapshot_ttl():
     api = StubSnapshotAPI(
         http_payload=_snapshot_payload(ttl_seconds=60, ttl_expire_at=120),
@@ -187,6 +221,20 @@ def test_snapshot_set_ttl_can_clear_snapshot_ttl():
     ]
     assert snapshot.ttl.ttl_seconds is None
     assert snapshot.ttl.ttl_expire_at is None
+
+
+@pytest.mark.parametrize("ttl_seconds", [0, -2])
+def test_snapshot_set_ttl_rejects_non_positive_values(ttl_seconds):
+    api = StubSnapshotAPI(
+        http_payload=_snapshot_payload(),
+        refresh_payload=_snapshot_payload(),
+    )
+    snapshot = Snapshot.model_validate(_snapshot_payload())._set_api(api)
+
+    with pytest.raises(ValueError, match="ttl_seconds must be greater than zero"):
+        snapshot.set_ttl(ttl_seconds)
+
+    assert api._http_client.post_calls == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- model snapshot TTLs in `Snapshot` responses and thread `ttl_seconds` through snapshot creation paths
- add `Snapshot.set_ttl(...)` / `aset_ttl(...)` plus CLI support to create, update, and clear snapshot TTLs
- document snapshot TTL usage in the README and add focused unit/integration coverage

## Validation
- `python3 -m pytest -q tests/unit/test_snapshot_ttl.py tests/unit/test_cli_snapshots.py`
- `python3 -m pytest -q tests/unit/test_snapshot_ttl.py tests/unit/test_cli_snapshots.py tests/integration/test_snapshot_operations.py -k snapshot_ttl`

## Notes
- Integration coverage in this repo is opt-in, so the new snapshot TTL integration path is skipped unless the integration environment is configured.
- An upstream `morph-cloud-runtime` OpenAPI update is still needed for generated API-reference coverage of snapshot TTL.