### PR TITLE
Managed SSH public keys SDK and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,15 +689,48 @@ morphcloud user api-key create
 # Delete an API key
 morphcloud user api-key delete <api_key_id>
 
-# Get your SSH public key
-morphcloud user ssh-key get
+# List named SSH public keys (fingerprints, expiry, and status)
+morphcloud user ssh-key list
 
-# Set/update your SSH public key
+# Add a user-owned public key; never provide the private key
+morphcloud user ssh-key add --name "Work laptop" --public-key-file ~/.ssh/id_ed25519.pub
+
+# Inspect and edit one managed key by its stable ID
+morphcloud user ssh-key get <ssh_key_id>
+morphcloud user ssh-key edit <ssh_key_id> --expires 2030-01-01T00:00:00Z
+
+# Revoke only that key across your current organization memberships
+morphcloud user ssh-key revoke <ssh_key_id>
+
+# Legacy singular compatibility commands remain available
+morphcloud user ssh-key get
 morphcloud user ssh-key set --public-key "ssh-rsa AAAA..."
 
 # View usage (3-hour lookback by default; supports 30m, 3h, 7d, etc.)
 morphcloud user usage --interval 3h
 ```
+
+The same managed-key lifecycle is typed in the SDK, with async methods using the
+usual `a` prefix (`alist_ssh_keys`, `aadd_ssh_key`, and so on):
+
+```python
+from pathlib import Path
+
+from morphcloud.api import MorphCloudClient
+
+client = MorphCloudClient()
+key = client.user.add_ssh_key(
+    name="Work laptop",
+    public_key=Path("~/.ssh/id_ed25519.pub").expanduser().read_text().strip(),
+)
+key = client.user.get_managed_ssh_key(key.id)
+key = client.user.edit_ssh_key(key.id, name="Work laptop (2026)")
+client.user.revoke_ssh_key(key.id)
+```
+
+Managed account public keys are separate from Morph-generated instance
+credentials and browser terminal access. A managed key is owned by one user and
+authorizes direct SSH through that user's current organization memberships.
 
 ## Advanced Features
 

--- a/morphcloud/api.py
+++ b/morphcloud/api.py
@@ -13,7 +13,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from functools import lru_cache
 
 import httpx
-from pydantic import BaseModel, Field, PrivateAttr
+from pydantic import BaseModel, Field, PrivateAttr, model_validator
 
 # Import Rich for fancy printing
 from rich.console import Console
@@ -52,9 +52,28 @@ class ApiError(Exception):
     def __init__(self, message: str, status_code: int, response_body: str):
         self.status_code = status_code
         self.response_body = response_body
+        self.error_code: typing.Optional[str] = None
+        self.detail: typing.Optional[str] = None
+        try:
+            payload = json.loads(response_body)
+            if isinstance(payload, dict):
+                error_code = payload.get("error_code")
+                detail = payload.get("detail")
+                if isinstance(error_code, str):
+                    self.error_code = error_code
+                if isinstance(detail, str):
+                    self.detail = detail
+        except (TypeError, ValueError):
+            pass
         super().__init__(
             f"{message}\nStatus Code: {status_code}\nResponse Body: {response_body}"
         )
+
+    def as_managed_ssh_key_error(self) -> typing.Optional["ManagedSSHKeyError"]:
+        """Return a typed managed-key error when the response uses that contract."""
+        if self.error_code is None or self.detail is None:
+            return None
+        return ManagedSSHKeyError(error_code=self.error_code, detail=self.detail)
 
 
 class ApiClient(httpx.Client):
@@ -441,27 +460,145 @@ class UserAPI(BaseAPI):
         await self._client._async_http_client.delete(f"/user/secret/{secret_name}")
 
     # ────────────────────────────────
-    # SSH Key
+    # Managed SSH public keys
+    # ────────────────────────────────
+    def list_ssh_keys(self) -> typing.List["ManagedSSHKey"]:
+        """List all managed SSH public keys owned by the authenticated user."""
+        response = self._client._http_client.get("/user/ssh-keys")
+        return ManagedSSHKeyList.model_validate(response.json()).data
+
+    async def alist_ssh_keys(self) -> typing.List["ManagedSSHKey"]:
+        """Asynchronously list all managed SSH public keys owned by the user."""
+        response = await self._client._async_http_client.get("/user/ssh-keys")
+        return ManagedSSHKeyList.model_validate(response.json()).data
+
+    def get_managed_ssh_key(self, ssh_key_id: str) -> "ManagedSSHKey":
+        """Get one managed SSH public key by its stable ID."""
+        response = self._client._http_client.get(f"/user/ssh-keys/{ssh_key_id}")
+        return ManagedSSHKey.model_validate(response.json())
+
+    async def aget_managed_ssh_key(self, ssh_key_id: str) -> "ManagedSSHKey":
+        """Asynchronously get one managed SSH public key by its stable ID."""
+        response = await self._client._async_http_client.get(
+            f"/user/ssh-keys/{ssh_key_id}"
+        )
+        return ManagedSSHKey.model_validate(response.json())
+
+    def add_ssh_key(
+        self,
+        name: str,
+        public_key: str,
+        expires: typing.Optional[int] = None,
+    ) -> "ManagedSSHKey":
+        """Add a named SSH public key, optionally expiring at Unix seconds."""
+        request_body = ManagedSSHKeyCreateRequest(
+            name=name, public_key=public_key, expires=expires
+        )
+        response = self._client._http_client.post(
+            "/user/ssh-keys", json=request_body.model_dump(exclude_none=True)
+        )
+        return ManagedSSHKey.model_validate(response.json())
+
+    async def aadd_ssh_key(
+        self,
+        name: str,
+        public_key: str,
+        expires: typing.Optional[int] = None,
+    ) -> "ManagedSSHKey":
+        """Asynchronously add a named SSH public key."""
+        request_body = ManagedSSHKeyCreateRequest(
+            name=name, public_key=public_key, expires=expires
+        )
+        response = await self._client._async_http_client.post(
+            "/user/ssh-keys", json=request_body.model_dump(exclude_none=True)
+        )
+        return ManagedSSHKey.model_validate(response.json())
+
+    def edit_ssh_key(
+        self,
+        ssh_key_id: str,
+        *,
+        name: typing.Optional[str] = None,
+        expires: typing.Optional[int] = None,
+        clear_expiry: bool = False,
+    ) -> "ManagedSSHKey":
+        """Edit a key's name or expiry without changing its public material.
+
+        Pass ``clear_expiry=True`` to send an explicit JSON null for ``expires``.
+        """
+        request_body = _managed_ssh_key_patch_request(
+            name=name, expires=expires, clear_expiry=clear_expiry
+        )
+        response = self._client._http_client.patch(
+            f"/user/ssh-keys/{ssh_key_id}",
+            json=request_body.model_dump(exclude_unset=True),
+        )
+        return ManagedSSHKey.model_validate(response.json())
+
+    async def aedit_ssh_key(
+        self,
+        ssh_key_id: str,
+        *,
+        name: typing.Optional[str] = None,
+        expires: typing.Optional[int] = None,
+        clear_expiry: bool = False,
+    ) -> "ManagedSSHKey":
+        """Asynchronously edit a key's name or expiry."""
+        request_body = _managed_ssh_key_patch_request(
+            name=name, expires=expires, clear_expiry=clear_expiry
+        )
+        response = await self._client._async_http_client.patch(
+            f"/user/ssh-keys/{ssh_key_id}",
+            json=request_body.model_dump(exclude_unset=True),
+        )
+        return ManagedSSHKey.model_validate(response.json())
+
+    def revoke_ssh_key(self, ssh_key_id: str) -> None:
+        """Permanently revoke one managed SSH public key by stable ID."""
+        self._client._http_client.delete(f"/user/ssh-keys/{ssh_key_id}")
+
+    async def arevoke_ssh_key(self, ssh_key_id: str) -> None:
+        """Asynchronously revoke one managed SSH public key by stable ID."""
+        await self._client._async_http_client.delete(f"/user/ssh-keys/{ssh_key_id}")
+
+    # ────────────────────────────────
+    # Legacy singular SSH key compatibility
     # ────────────────────────────────
     def get_ssh_key(self) -> "UserSSHKey":
+        """Get the legacy singular key through its compatibility endpoint."""
         response = self._client._http_client.get("/user/ssh-key")
         return UserSSHKey.model_validate(response.json())
 
     async def aget_ssh_key(self) -> "UserSSHKey":
+        """Asynchronously get the legacy singular compatibility key."""
         response = await self._client._async_http_client.get("/user/ssh-key")
         return UserSSHKey.model_validate(response.json())
 
     def update_ssh_key(self, public_key: str) -> "UserSSHKey":
+        """Set the legacy singular compatibility key.
+
+        New integrations should use :meth:`add_ssh_key`, then revoke the old key
+        only after verifying the replacement.
+        """
         response = self._client._http_client.put(
             "/user/ssh-key", json={"public_key": public_key}
         )
         return UserSSHKey.model_validate(response.json())
 
     async def aupdate_ssh_key(self, public_key: str) -> "UserSSHKey":
+        """Asynchronously set the legacy singular compatibility key."""
         response = await self._client._async_http_client.put(
             "/user/ssh-key", json={"public_key": public_key}
         )
         return UserSSHKey.model_validate(response.json())
+
+    def set_ssh_key(self, public_key: str) -> "UserSSHKey":
+        """Compatibility alias for :meth:`update_ssh_key`."""
+        return self.update_ssh_key(public_key)
+
+    async def aset_ssh_key(self, public_key: str) -> "UserSSHKey":
+        """Async compatibility alias for :meth:`aupdate_ssh_key`."""
+        return await self.aupdate_ssh_key(public_key)
 
     # ────────────────────────────────
     # Usage
@@ -535,8 +672,83 @@ class CreateSecretRequest(BaseModel):
 
 
 class UserSSHKey(BaseModel):
+    """Legacy singular user SSH-key response."""
+
     public_key: str
     created: int
+
+
+class ManagedSSHKeyStatus(StrEnum):
+    ACTIVE = "active"
+    EXPIRED = "expired"
+    REVOKED = "revoked"
+    MIGRATION_WARNING = "migration_warning"
+
+
+class ManagedSSHKey(BaseModel):
+    """A user-owned SSH public key accepted through current org memberships."""
+
+    object: typing.Literal["user_ssh_key"] = "user_ssh_key"
+    id: str
+    name: str
+    public_key: str
+    fingerprint: str
+    algorithm: str
+    created: int
+    updated: int
+    expires: typing.Optional[int] = None
+    last_used: typing.Optional[int] = None
+    revoked: typing.Optional[int] = None
+    status: ManagedSSHKeyStatus
+    migrated_from_legacy: bool = False
+    migration_warning: bool = False
+
+
+class ManagedSSHKeyList(BaseModel):
+    object: typing.Literal["list"] = "list"
+    data: typing.List[ManagedSSHKey]
+
+
+class ManagedSSHKeyCreateRequest(BaseModel):
+    name: str
+    public_key: str
+    expires: typing.Optional[int] = None
+
+
+class ManagedSSHKeyPatchRequest(BaseModel):
+    name: typing.Optional[str] = None
+    expires: typing.Optional[int] = None
+
+    @model_validator(mode="after")
+    def require_change(self) -> "ManagedSSHKeyPatchRequest":
+        if not self.model_fields_set:
+            raise ValueError("at least one of name or expires must be provided")
+        return self
+
+
+class ManagedSSHKeyError(BaseModel):
+    """Stable machine-readable error returned by managed-key endpoints."""
+
+    detail: str
+    error_code: str
+
+
+def _managed_ssh_key_patch_request(
+    *,
+    name: typing.Optional[str],
+    expires: typing.Optional[int],
+    clear_expiry: bool,
+) -> ManagedSSHKeyPatchRequest:
+    if clear_expiry and expires is not None:
+        raise ValueError("expires and clear_expiry cannot be used together")
+    values: typing.Dict[str, typing.Any] = {}
+    if name is not None:
+        values["name"] = name
+    if clear_expiry:
+        values["expires"] = None
+    elif expires is not None:
+        values["expires"] = expires
+    return ManagedSSHKeyPatchRequest(**values)
 
 
 class UserInstanceUsage(BaseModel):

--- a/morphcloud/cli.py
+++ b/morphcloud/cli.py
@@ -4,6 +4,7 @@ import datetime
 import importlib.metadata
 import json
 import os
+import pathlib
 import shlex
 import sys
 import termios
@@ -861,20 +862,153 @@ def user_secret_delete(name):
 cli.add_command(user_secret, name="secrets")
 
 
-# ── SSH Key ─────────────────────────────────────────────────
+# ── Managed SSH public keys ─────────────────────────────────
 
 
 @user.group(cls=AliasedGroup, name="ssh-key")
 def user_ssh_key():
-    """Manage user SSH public key."""
+    """Manage user-owned SSH public keys used for direct SSH."""
     pass
 
 
-@user_ssh_key.command(name="get")
+def _read_ssh_public_key(
+    public_key: typing.Optional[str], public_key_file: typing.Optional[str]
+) -> str:
+    if public_key is not None and public_key_file is not None:
+        raise click.ClickException(
+            "Use either --public-key or --public-key-file, not both."
+        )
+    if public_key_file is not None:
+        path = pathlib.Path(public_key_file)
+        if path.suffix.lower() != ".pub":
+            raise click.ClickException(
+                "--public-key-file must point to a public .pub file, never a private key."
+            )
+        try:
+            public_key = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            raise click.ClickException(
+                f"Could not read public-key file: {exc}"
+            ) from exc
+    if public_key is None:
+        raise click.ClickException(
+            "Provide the public key with --public-key or --public-key-file."
+        )
+    value = public_key.strip()
+    if not value:
+        raise click.ClickException("SSH public key cannot be empty.")
+    if "PRIVATE KEY" in value:
+        raise click.ClickException(
+            "Private keys are not accepted. Provide only the public .pub value."
+        )
+    if "\n" in value or "\r" in value:
+        raise click.ClickException("Provide exactly one SSH public key.")
+    return value
+
+
+def _parse_ssh_expiry(
+    ctx: click.Context,
+    param: typing.Optional[click.Parameter],
+    value: typing.Optional[str],
+) -> typing.Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        parsed = datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise click.BadParameter(
+            "must be Unix seconds or an ISO 8601 datetime", ctx=ctx, param=param
+        ) from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=datetime.timezone.utc)
+    return int(parsed.timestamp())
+
+
+@user_ssh_key.command(name="list", aliases=["ls"])
 @click.option("--json", "json_mode", is_flag=True, default=False)
-def user_ssh_key_get(json_mode):
+def user_ssh_key_list(json_mode):
+    """List managed SSH public keys."""
     client = get_client()
     try:
+        keys = client.user.list_ssh_keys()
+        if json_mode:
+            click.echo(
+                json.dumps([key.model_dump(mode="json") for key in keys], indent=2)
+            )
+        else:
+            headers = [
+                "ID",
+                "Name",
+                "Algorithm",
+                "Fingerprint",
+                "Status",
+                "Created",
+                "Last Used",
+                "Expires",
+            ]
+            rows = [
+                [
+                    key.id,
+                    key.name,
+                    key.algorithm,
+                    key.fingerprint,
+                    key.status.value,
+                    unix_timestamp_to_datetime(key.created),
+                    unix_timestamp_to_datetime(key.last_used),
+                    unix_timestamp_to_datetime(key.expires),
+                ]
+                for key in keys
+            ]
+            print_docker_style_table(headers, rows)
+    except Exception as e:
+        handle_api_error(e)
+
+
+@user_ssh_key.command(name="get")
+@click.argument("ssh_key_id", required=False)
+@click.option("--json", "json_mode", is_flag=True, default=False)
+def user_ssh_key_get(ssh_key_id, json_mode):
+    """Get a managed key by ID, or the legacy singular key when ID is omitted."""
+    client = get_client()
+    try:
+        if ssh_key_id is not None:
+            info = client.user.get_managed_ssh_key(ssh_key_id)
+            if json_mode:
+                click.echo(format_json(info))
+            else:
+                headers = [
+                    "ID",
+                    "Name",
+                    "Algorithm",
+                    "Fingerprint",
+                    "Status",
+                    "Created",
+                    "Updated",
+                    "Last Used",
+                    "Expires",
+                    "Revoked",
+                ]
+                rows = [
+                    [
+                        info.id,
+                        info.name,
+                        info.algorithm,
+                        info.fingerprint,
+                        info.status.value,
+                        unix_timestamp_to_datetime(info.created),
+                        unix_timestamp_to_datetime(info.updated),
+                        unix_timestamp_to_datetime(info.last_used),
+                        unix_timestamp_to_datetime(info.expires),
+                        unix_timestamp_to_datetime(info.revoked),
+                    ]
+                ]
+                print_docker_style_table(headers, rows)
+            return
+
         info = client.user.get_ssh_key()
         if json_mode:
             click.echo(format_json(info))
@@ -882,6 +1016,120 @@ def user_ssh_key_get(json_mode):
             headers = ["Public Key", "Created"]
             rows = [[info.public_key, unix_timestamp_to_datetime(info.created)]]
             print_docker_style_table(headers, rows)
+    except Exception as e:
+        handle_api_error(e)
+
+
+@user_ssh_key.command(name="add", aliases=["create"])
+@click.option("--name", required=True, help="A unique, recognizable device name.")
+@click.option("--public-key", default=None, help="One OpenSSH public-key value.")
+@click.option(
+    "--public-key-file",
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+    default=None,
+    help="Read the public key from a .pub file.",
+)
+@click.option(
+    "--expires",
+    callback=_parse_ssh_expiry,
+    default=None,
+    help="Optional expiry as Unix seconds or ISO 8601 (naive values are UTC).",
+)
+@click.option("--json", "json_mode", is_flag=True, default=False)
+def user_ssh_key_add(name, public_key, public_key_file, expires, json_mode):
+    """Add a managed SSH public key.
+
+    A user-owned key authorizes direct SSH through all current organization
+    memberships. Morph never asks for or stores the corresponding private key.
+    """
+    key_value = _read_ssh_public_key(public_key, public_key_file)
+    client = get_client()
+    try:
+        with Spinner(
+            text="Adding SSH public key...",
+            success_text="SSH public key added",
+            success_emoji="🔐",
+        ):
+            info = client.user.add_ssh_key(
+                name=name, public_key=key_value, expires=expires
+            )
+        if json_mode:
+            click.echo(format_json(info))
+        else:
+            click.secho("SSH public key added.", fg="green")
+            click.echo(f"ID: {info.id}")
+            click.echo(f"Name: {info.name}")
+            click.echo(f"Fingerprint: {info.fingerprint}")
+    except Exception as e:
+        handle_api_error(e)
+
+
+@user_ssh_key.command(name="edit")
+@click.argument("ssh_key_id")
+@click.option("--name", default=None, help="New recognizable device name.")
+@click.option(
+    "--expires",
+    callback=_parse_ssh_expiry,
+    default=None,
+    help="New expiry as Unix seconds or ISO 8601.",
+)
+@click.option(
+    "--clear-expiry",
+    is_flag=True,
+    default=False,
+    help="Remove the key's existing expiry.",
+)
+@click.option("--json", "json_mode", is_flag=True, default=False)
+def user_ssh_key_edit(ssh_key_id, name, expires, clear_expiry, json_mode):
+    """Edit a managed key's name or expiry; public material is immutable."""
+    if name is None and expires is None and not clear_expiry:
+        raise click.ClickException(
+            "Provide at least one of --name, --expires, or --clear-expiry."
+        )
+    if expires is not None and clear_expiry:
+        raise click.ClickException("Use either --expires or --clear-expiry, not both.")
+
+    client = get_client()
+    try:
+        with Spinner(
+            text="Editing SSH public key...",
+            success_text="SSH public key edited",
+            success_emoji="🔐",
+        ):
+            info = client.user.edit_ssh_key(
+                ssh_key_id, name=name, expires=expires, clear_expiry=clear_expiry
+            )
+        if json_mode:
+            click.echo(format_json(info))
+        else:
+            click.secho("SSH public key edited.", fg="green")
+            click.echo(f"ID: {info.id}")
+            click.echo(f"Name: {info.name}")
+            click.echo(f"Expires: {unix_timestamp_to_datetime(info.expires)}")
+    except Exception as e:
+        handle_api_error(e)
+
+
+@user_ssh_key.command(name="revoke", aliases=["rm"])
+@click.argument("ssh_key_id")
+@click.option("--yes", is_flag=True, help="Skip the confirmation prompt.")
+def user_ssh_key_revoke(ssh_key_id, yes):
+    """Revoke one managed key across all current organization memberships."""
+    if not yes:
+        click.confirm(
+            "Revoke this key for direct SSH across all current organization "
+            "memberships? Browser terminal and instance credentials are separate.",
+            abort=True,
+        )
+    client = get_client()
+    try:
+        with Spinner(
+            text="Revoking SSH public key...",
+            success_text="SSH public key revoked",
+            success_emoji="🗑",
+        ):
+            client.user.revoke_ssh_key(ssh_key_id)
+        click.secho("SSH public key revoked.", fg="green")
     except Exception as e:
         handle_api_error(e)
 
@@ -894,6 +1142,10 @@ def user_ssh_key_get(json_mode):
 )
 @click.option("--json", "json_mode", is_flag=True, default=False)
 def user_ssh_key_set(public_key, json_mode):
+    """Set the legacy singular compatibility key.
+
+    Prefer ``add`` for safe overlap rotation with managed keys.
+    """
     client = get_client()
     try:
         with Spinner(
@@ -901,7 +1153,7 @@ def user_ssh_key_set(public_key, json_mode):
             success_text="SSH key updated",
             success_emoji="🔐",
         ):
-            info = client.user.update_ssh_key(public_key)
+            info = client.user.set_ssh_key(public_key)
         if json_mode:
             click.echo(format_json(info))
         else:

--- a/tests/integration/test_managed_ssh_keys.py
+++ b/tests/integration/test_managed_ssh_keys.py
@@ -1,0 +1,146 @@
+"""Stage/production contract tests for user-managed SSH public keys.
+
+Run only after the plural runtime API is deployed in the selected environment:
+
+    MORPH_RUN_INTEGRATION_TESTS=1 MORPH_TARGET=stage MORPH_API_HOST=stage.morph.so \
+    MORPH_BASE_URL=https://stage.morph.so/api MORPH_API_KEY=... \
+    pytest -q tests/integration/test_managed_ssh_keys.py
+
+or:
+
+    MORPH_RUN_INTEGRATION_TESTS=1 MORPH_TARGET=prod MORPH_API_HOST=cloud.morph.so \
+    MORPH_BASE_URL=https://cloud.morph.so/api MORPH_API_KEY=... \
+    pytest -q tests/integration/test_managed_ssh_keys.py
+
+Only these exact environment tuples are accepted; there is no target fallback.
+The tests add unique generated public keys and always target those stable IDs for
+cleanup. They never read or replace the legacy singular/default key.
+"""
+
+import os
+import time
+import uuid
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+pytestmark = pytest.mark.asyncio
+
+_MANAGED_KEY_CONTRACTS = frozenset(
+    {
+        ("stage", "stage.morph.so", "https://stage.morph.so/api"),
+        ("prod", "cloud.morph.so", "https://cloud.morph.so/api"),
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def managed_key_target() -> str:
+    contract = (
+        os.environ.get("MORPH_TARGET"),
+        os.environ.get("MORPH_API_HOST"),
+        os.environ.get("MORPH_BASE_URL"),
+    )
+    assert contract in _MANAGED_KEY_CONTRACTS
+    return contract[0]
+
+
+def _generated_public_key(comment: str) -> str:
+    private_key = Ed25519PrivateKey.generate()
+    public_key = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.OpenSSH,
+        format=serialization.PublicFormat.OpenSSH,
+    )
+    return f"{public_key.decode('ascii')} {comment}"
+
+
+async def test_managed_ssh_key_lifecycle_sync(client, managed_key_target: str):
+    suffix = uuid.uuid4().hex[:12]
+    original_name = f"SDK {managed_key_target} e2e sync {suffix}"
+    edited_name = f"SDK {managed_key_target} e2e sync edited {suffix}"
+    public_key = _generated_public_key(
+        f"morph-sdk-{managed_key_target}-e2e-sync-{suffix}"
+    )
+    created = None
+
+    try:
+        created = client.user.add_ssh_key(name=original_name, public_key=public_key)
+        assert created.name == original_name
+        assert created.public_key == public_key
+        assert created.algorithm == "ssh-ed25519"
+        assert created.fingerprint.startswith("SHA256:")
+        assert created.status.value == "active"
+
+        listed = client.user.list_ssh_keys()
+        assert any(item.id == created.id for item in listed)
+        fetched = client.user.get_managed_ssh_key(created.id)
+        assert fetched == created
+
+        expires = int(time.time()) + 3600
+        edited = client.user.edit_ssh_key(created.id, name=edited_name, expires=expires)
+        assert edited.id == created.id
+        assert edited.name == edited_name
+        assert edited.expires == expires
+        assert edited.public_key == public_key
+    finally:
+        cleanup_ids = {
+            item.id
+            for item in client.user.list_ssh_keys()
+            if item.name in {original_name, edited_name} and item.revoked is None
+        }
+        if created is not None and created.revoked is None:
+            cleanup_ids.add(created.id)
+        for key_id in cleanup_ids:
+            client.user.revoke_ssh_key(key_id)
+
+    revoked = client.user.get_managed_ssh_key(created.id)
+    assert revoked.status.value == "revoked"
+    assert revoked.revoked is not None
+
+
+async def test_managed_ssh_key_lifecycle_async(client, managed_key_target: str):
+    suffix = uuid.uuid4().hex[:12]
+    original_name = f"SDK {managed_key_target} e2e async {suffix}"
+    edited_name = f"SDK {managed_key_target} e2e async edited {suffix}"
+    public_key = _generated_public_key(
+        f"morph-sdk-{managed_key_target}-e2e-async-{suffix}"
+    )
+    created = None
+
+    try:
+        created = await client.user.aadd_ssh_key(
+            name=original_name, public_key=public_key
+        )
+        assert created.name == original_name
+        assert created.public_key == public_key
+        assert created.algorithm == "ssh-ed25519"
+        assert created.fingerprint.startswith("SHA256:")
+        assert created.status.value == "active"
+
+        listed = await client.user.alist_ssh_keys()
+        assert any(item.id == created.id for item in listed)
+        fetched = await client.user.aget_managed_ssh_key(created.id)
+        assert fetched == created
+
+        edited = await client.user.aedit_ssh_key(
+            created.id, name=edited_name, clear_expiry=True
+        )
+        assert edited.id == created.id
+        assert edited.name == edited_name
+        assert edited.expires is None
+        assert edited.public_key == public_key
+    finally:
+        cleanup_ids = {
+            item.id
+            for item in await client.user.alist_ssh_keys()
+            if item.name in {original_name, edited_name} and item.revoked is None
+        }
+        if created is not None and created.revoked is None:
+            cleanup_ids.add(created.id)
+        for key_id in cleanup_ids:
+            await client.user.arevoke_ssh_key(key_id)
+
+    revoked = await client.user.aget_managed_ssh_key(created.id)
+    assert revoked.status.value == "revoked"
+    assert revoked.revoked is not None

--- a/tests/unit/test_cli_managed_ssh_keys.py
+++ b/tests/unit/test_cli_managed_ssh_keys.py
@@ -1,0 +1,249 @@
+import json
+import types
+
+import pytest
+from click.testing import CliRunner
+
+from morphcloud.api import ManagedSSHKey, UserSSHKey
+
+PUBLIC_KEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITest cli@example"
+KEY = ManagedSSHKey(
+    id="usk_cli",
+    name="Work laptop",
+    public_key=PUBLIC_KEY,
+    fingerprint="SHA256:CliTest",
+    algorithm="ssh-ed25519",
+    created=1_700_000_000,
+    updated=1_700_000_001,
+    expires=None,
+    last_used=None,
+    revoked=None,
+    status="active",
+)
+
+
+def _install_noop_spinner(monkeypatch):
+    import morphcloud.cli as cli_mod
+
+    class NoopSpinner:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(cli_mod, "Spinner", NoopSpinner)
+
+
+def _invoke(monkeypatch, user, argv, *, input=None):
+    import morphcloud.cli as cli_mod
+
+    _install_noop_spinner(monkeypatch)
+    monkeypatch.setattr(cli_mod, "get_client", lambda: types.SimpleNamespace(user=user))
+    return CliRunner().invoke(cli_mod.cli, ["user", "ssh-key", *argv], input=input)
+
+
+@pytest.mark.parametrize("command", ["list", "get", "add", "edit", "revoke", "set"])
+def test_managed_ssh_key_commands_are_documented(command):
+    import morphcloud.cli as cli_mod
+
+    result = CliRunner().invoke(cli_mod.cli, ["user", "ssh-key", command, "--help"])
+    assert result.exit_code == 0, result.output
+
+
+def test_list_outputs_typed_json(monkeypatch):
+    user = types.SimpleNamespace(list_ssh_keys=lambda: [KEY])
+    result = _invoke(monkeypatch, user, ["list", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload[0]["id"] == "usk_cli"
+    assert payload[0]["status"] == "active"
+
+
+def test_list_outputs_auditable_columns(monkeypatch):
+    user = types.SimpleNamespace(list_ssh_keys=lambda: [KEY])
+    result = _invoke(monkeypatch, user, ["list"])
+    assert result.exit_code == 0, result.output
+    assert "Fingerprint" in result.output
+    assert "SHA256:CliTest" in result.output
+    assert "Work laptop" in result.output
+
+
+def test_get_with_id_uses_plural_endpoint_method(monkeypatch):
+    calls = []
+    user = types.SimpleNamespace(
+        get_managed_ssh_key=lambda key_id: calls.append(key_id) or KEY
+    )
+    result = _invoke(monkeypatch, user, ["get", "usk_cli", "--json"])
+    assert result.exit_code == 0, result.output
+    assert calls == ["usk_cli"]
+    assert json.loads(result.output)["fingerprint"] == "SHA256:CliTest"
+
+
+def test_get_without_id_retains_legacy_behavior(monkeypatch):
+    user = types.SimpleNamespace(
+        get_ssh_key=lambda: UserSSHKey(public_key=PUBLIC_KEY, created=1)
+    )
+    result = _invoke(monkeypatch, user, ["get", "--json"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == {"public_key": PUBLIC_KEY, "created": 1}
+
+
+def test_add_accepts_public_key_text_and_iso_expiry(monkeypatch):
+    calls = []
+
+    def add_ssh_key(**kwargs):
+        calls.append(kwargs)
+        return KEY
+
+    result = _invoke(
+        monkeypatch,
+        types.SimpleNamespace(add_ssh_key=add_ssh_key),
+        [
+            "add",
+            "--name",
+            "Work laptop",
+            "--public-key",
+            PUBLIC_KEY,
+            "--expires",
+            "2030-01-01T00:00:00Z",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        {
+            "name": "Work laptop",
+            "public_key": PUBLIC_KEY,
+            "expires": 1_893_456_000,
+        }
+    ]
+
+
+def test_add_reads_exactly_one_public_key_from_pub_file(monkeypatch, tmp_path):
+    pub_file = tmp_path / "id_ed25519.pub"
+    pub_file.write_text(f"{PUBLIC_KEY}\n", encoding="utf-8")
+    calls = []
+    user = types.SimpleNamespace(
+        add_ssh_key=lambda **kwargs: calls.append(kwargs) or KEY
+    )
+    result = _invoke(
+        monkeypatch,
+        user,
+        ["add", "--name", "Work laptop", "--public-key-file", str(pub_file)],
+    )
+    assert result.exit_code == 0, result.output
+    assert calls[0]["public_key"] == PUBLIC_KEY
+
+
+@pytest.mark.parametrize(
+    "argv, expected",
+    [
+        (
+            ["--public-key", PUBLIC_KEY, "--public-key-file", "id.pub"],
+            "either --public-key or --public-key-file",
+        ),
+        (
+            ["--public-key", "-----BEGIN PRIVATE KEY-----"],
+            "Private keys are not accepted",
+        ),
+        (
+            ["--public-key", f"{PUBLIC_KEY}\n{PUBLIC_KEY}"],
+            "exactly one SSH public key",
+        ),
+    ],
+)
+def test_add_rejects_ambiguous_or_private_input(monkeypatch, tmp_path, argv, expected):
+    pub_file = tmp_path / "id.pub"
+    pub_file.write_text(PUBLIC_KEY, encoding="utf-8")
+    argv = [str(pub_file) if item == "id.pub" else item for item in argv]
+    result = _invoke(
+        monkeypatch,
+        types.SimpleNamespace(),
+        ["add", "--name", "Unsafe", *argv],
+    )
+    assert result.exit_code != 0
+    assert expected in result.output
+
+
+def test_add_refuses_non_pub_file(monkeypatch, tmp_path):
+    private_file = tmp_path / "id_ed25519"
+    private_file.write_text("not a public file", encoding="utf-8")
+    result = _invoke(
+        monkeypatch,
+        types.SimpleNamespace(),
+        ["add", "--name", "Unsafe", "--public-key-file", str(private_file)],
+    )
+    assert result.exit_code != 0
+    assert "public .pub file" in result.output
+
+
+@pytest.mark.parametrize(
+    "argv, expected",
+    [
+        (
+            ["--name", "Office"],
+            {"name": "Office", "expires": None, "clear_expiry": False},
+        ),
+        (["--clear-expiry"], {"name": None, "expires": None, "clear_expiry": True}),
+        (
+            ["--expires", "1800000000"],
+            {"name": None, "expires": 1_800_000_000, "clear_expiry": False},
+        ),
+    ],
+)
+def test_edit_sends_only_deliberate_metadata_change(monkeypatch, argv, expected):
+    calls = []
+
+    def edit_ssh_key(key_id, **kwargs):
+        calls.append((key_id, kwargs))
+        return KEY
+
+    result = _invoke(
+        monkeypatch,
+        types.SimpleNamespace(edit_ssh_key=edit_ssh_key),
+        ["edit", "usk_cli", *argv],
+    )
+    assert result.exit_code == 0, result.output
+    assert calls == [("usk_cli", expected)]
+
+
+def test_edit_rejects_empty_or_conflicting_change(monkeypatch):
+    result = _invoke(monkeypatch, types.SimpleNamespace(), ["edit", "usk_cli"])
+    assert result.exit_code != 0
+    assert "Provide at least one" in result.output
+
+    result = _invoke(
+        monkeypatch,
+        types.SimpleNamespace(),
+        ["edit", "usk_cli", "--expires", "1800000000", "--clear-expiry"],
+    )
+    assert result.exit_code != 0
+    assert "either --expires or --clear-expiry" in result.output
+
+
+def test_revoke_requires_confirmation_and_targets_one_id(monkeypatch):
+    calls = []
+    user = types.SimpleNamespace(revoke_ssh_key=lambda key_id: calls.append(key_id))
+    result = _invoke(monkeypatch, user, ["revoke", "usk_cli"], input="n\n")
+    assert result.exit_code != 0
+    assert calls == []
+
+    result = _invoke(monkeypatch, user, ["revoke", "usk_cli", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert calls == ["usk_cli"]
+
+
+def test_set_retains_legacy_singular_alias(monkeypatch):
+    calls = []
+    user = types.SimpleNamespace(
+        set_ssh_key=lambda public_key: (
+            calls.append(public_key) or UserSSHKey(public_key=public_key, created=1)
+        )
+    )
+    result = _invoke(monkeypatch, user, ["set", "--public-key", PUBLIC_KEY, "--json"])
+    assert result.exit_code == 0, result.output
+    assert calls == [PUBLIC_KEY]

--- a/tests/unit/test_managed_ssh_keys_api.py
+++ b/tests/unit/test_managed_ssh_keys_api.py
@@ -1,0 +1,233 @@
+import json
+
+import httpx
+import pytest
+
+from morphcloud.api import (
+    ApiClient,
+    ApiError,
+    AsyncApiClient,
+    ManagedSSHKey,
+    ManagedSSHKeyError,
+    ManagedSSHKeyPatchRequest,
+    ManagedSSHKeyStatus,
+    MorphCloudClient,
+)
+
+KEY = {
+    "object": "user_ssh_key",
+    "id": "usk_123",
+    "name": "Work laptop",
+    "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITest test@example",
+    "fingerprint": "SHA256:AbCdEf",
+    "algorithm": "ssh-ed25519",
+    "created": 1_700_000_000,
+    "updated": 1_700_000_001,
+    "expires": 1_800_000_000,
+    "last_used": None,
+    "revoked": None,
+    "status": "active",
+    "migrated_from_legacy": False,
+    "migration_warning": False,
+}
+
+
+def _client(handler):
+    client = MorphCloudClient(
+        api_key="test-key", base_url="https://api.example.test/api"
+    )
+    client._http_client.close()
+    client._http_client = ApiClient(
+        base_url=client.base_url, transport=httpx.MockTransport(handler)
+    )
+    client._async_http_client = AsyncApiClient(
+        base_url=client.base_url, transport=httpx.MockTransport(handler)
+    )
+    return client
+
+
+def _json_request(request):
+    return json.loads(request.content.decode()) if request.content else None
+
+
+def test_managed_ssh_key_models_cover_lifecycle_and_structured_error():
+    key = ManagedSSHKey.model_validate(KEY)
+    assert key.id == "usk_123"
+    assert key.status is ManagedSSHKeyStatus.ACTIVE
+    assert key.expires == 1_800_000_000
+    assert key.last_used is None
+    assert key.revoked is None
+    assert key.migrated_from_legacy is False
+    assert key.migration_warning is False
+
+    error = ManagedSSHKeyError.model_validate(
+        {"detail": "that key is already registered", "error_code": "duplicate_ssh_key"}
+    )
+    assert error.error_code == "duplicate_ssh_key"
+
+
+def test_patch_model_requires_a_change_and_preserves_explicit_null():
+    with pytest.raises(ValueError, match="at least one"):
+        ManagedSSHKeyPatchRequest()
+
+    patch = ManagedSSHKeyPatchRequest(expires=None)
+    assert patch.model_dump(exclude_unset=True) == {"expires": None}
+
+
+def test_sync_managed_ssh_key_contract_and_legacy_aliases():
+    seen = []
+
+    def handler(request):
+        seen.append((request.method, request.url.path, _json_request(request)))
+        path = request.url.path
+        if request.method == "GET" and path == "/api/user/ssh-keys":
+            return httpx.Response(200, json={"object": "list", "data": [KEY]})
+        if request.method == "GET" and path == "/api/user/ssh-keys/usk_123":
+            return httpx.Response(200, json=KEY)
+        if request.method == "POST" and path == "/api/user/ssh-keys":
+            return httpx.Response(201, json=KEY)
+        if request.method == "PATCH" and path == "/api/user/ssh-keys/usk_123":
+            body = _json_request(request)
+            return httpx.Response(200, json={**KEY, **body, "updated": 1_700_000_002})
+        if request.method == "DELETE" and path == "/api/user/ssh-keys/usk_123":
+            return httpx.Response(204)
+        if request.method == "GET" and path == "/api/user/ssh-key":
+            return httpx.Response(
+                200, json={"public_key": KEY["public_key"], "created": 1}
+            )
+        if request.method == "PUT" and path == "/api/user/ssh-key":
+            return httpx.Response(200, json={**_json_request(request), "created": 2})
+        raise AssertionError(f"unexpected request: {request.method} {path}")
+
+    client = _client(handler)
+    assert [key.id for key in client.user.list_ssh_keys()] == ["usk_123"]
+    assert client.user.get_managed_ssh_key("usk_123").name == "Work laptop"
+    assert (
+        client.user.add_ssh_key(
+            name="Work laptop", public_key=KEY["public_key"], expires=1_800_000_000
+        ).id
+        == "usk_123"
+    )
+    assert client.user.edit_ssh_key("usk_123", name="Office").name == "Office"
+    assert client.user.edit_ssh_key("usk_123", clear_expiry=True).expires is None
+    assert client.user.revoke_ssh_key("usk_123") is None
+    assert client.user.get_ssh_key().public_key == KEY["public_key"]
+    assert client.user.set_ssh_key(KEY["public_key"]).created == 2
+    assert client.user.update_ssh_key(KEY["public_key"]).created == 2
+
+    assert seen == [
+        ("GET", "/api/user/ssh-keys", None),
+        ("GET", "/api/user/ssh-keys/usk_123", None),
+        (
+            "POST",
+            "/api/user/ssh-keys",
+            {
+                "name": "Work laptop",
+                "public_key": KEY["public_key"],
+                "expires": 1_800_000_000,
+            },
+        ),
+        ("PATCH", "/api/user/ssh-keys/usk_123", {"name": "Office"}),
+        ("PATCH", "/api/user/ssh-keys/usk_123", {"expires": None}),
+        ("DELETE", "/api/user/ssh-keys/usk_123", None),
+        ("GET", "/api/user/ssh-key", None),
+        ("PUT", "/api/user/ssh-key", {"public_key": KEY["public_key"]}),
+        ("PUT", "/api/user/ssh-key", {"public_key": KEY["public_key"]}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_managed_ssh_key_contract_and_legacy_aliases():
+    seen = []
+
+    def handler(request):
+        seen.append((request.method, request.url.path, _json_request(request)))
+        path = request.url.path
+        if request.method == "GET" and path == "/api/user/ssh-keys":
+            return httpx.Response(200, json={"object": "list", "data": [KEY]})
+        if request.method == "GET" and path == "/api/user/ssh-keys/usk_123":
+            return httpx.Response(200, json=KEY)
+        if request.method == "POST" and path == "/api/user/ssh-keys":
+            return httpx.Response(201, json=KEY)
+        if request.method == "PATCH" and path == "/api/user/ssh-keys/usk_123":
+            return httpx.Response(200, json={**KEY, **_json_request(request)})
+        if request.method == "DELETE" and path == "/api/user/ssh-keys/usk_123":
+            return httpx.Response(204)
+        if request.method == "GET" and path == "/api/user/ssh-key":
+            return httpx.Response(
+                200, json={"public_key": KEY["public_key"], "created": 1}
+            )
+        if request.method == "PUT" and path == "/api/user/ssh-key":
+            return httpx.Response(200, json={**_json_request(request), "created": 2})
+        raise AssertionError(f"unexpected request: {request.method} {path}")
+
+    client = _client(handler)
+    assert [key.id for key in await client.user.alist_ssh_keys()] == ["usk_123"]
+    assert (await client.user.aget_managed_ssh_key("usk_123")).id == "usk_123"
+    assert (
+        await client.user.aadd_ssh_key(name="Work laptop", public_key=KEY["public_key"])
+    ).id == "usk_123"
+    assert (await client.user.aedit_ssh_key("usk_123", name="Office")).name == "Office"
+    assert (
+        await client.user.aedit_ssh_key("usk_123", clear_expiry=True)
+    ).expires is None
+    assert await client.user.arevoke_ssh_key("usk_123") is None
+    assert (await client.user.aget_ssh_key()).created == 1
+    assert (await client.user.aset_ssh_key(KEY["public_key"])).created == 2
+    assert (await client.user.aupdate_ssh_key(KEY["public_key"])).created == 2
+
+    assert seen[2] == (
+        "POST",
+        "/api/user/ssh-keys",
+        {"name": "Work laptop", "public_key": KEY["public_key"]},
+    )
+    assert seen[3] == (
+        "PATCH",
+        "/api/user/ssh-keys/usk_123",
+        {"name": "Office"},
+    )
+    assert seen[4] == (
+        "PATCH",
+        "/api/user/ssh-keys/usk_123",
+        {"expires": None},
+    )
+
+
+def test_structured_api_error_is_available_without_losing_response_body():
+    def handler(request):
+        return httpx.Response(
+            409,
+            json={
+                "detail": "that key is already registered",
+                "error_code": "duplicate_ssh_key",
+            },
+        )
+
+    client = _client(handler)
+    with pytest.raises(ApiError) as exc_info:
+        client.user.add_ssh_key(name="duplicate", public_key=KEY["public_key"])
+
+    error = exc_info.value
+    assert error.status_code == 409
+    assert error.error_code == "duplicate_ssh_key"
+    assert error.detail == "that key is already registered"
+    assert error.as_managed_ssh_key_error() == ManagedSSHKeyError(
+        detail="that key is already registered", error_code="duplicate_ssh_key"
+    )
+    assert "duplicate_ssh_key" in error.response_body
+
+
+@pytest.mark.parametrize(
+    "kwargs, message",
+    [
+        ({}, "at least one"),
+        (
+            {"expires": 1_800_000_000, "clear_expiry": True},
+            "expires and clear_expiry cannot be used together",
+        ),
+    ],
+)
+def test_edit_rejects_ambiguous_or_empty_updates(kwargs, message):
+    client = _client(lambda request: pytest.fail("request must not be sent"))
+    with pytest.raises(ValueError, match=message):
+        client.user.edit_ssh_key("usk_123", **kwargs)


### PR DESCRIPTION
## Summary
- exact git-am replay of the private-fork public-ready managed SSH key SDK and CLI candidate
- add typed sync and async list, get, add, edit, and revoke methods
- preserve singular get, set, and update compatibility behavior
- add exact HTTP contract, CLI, compatibility, and production lifecycle tests

## Verification
- source private commit: e75fd35efc8c3588e965beff10d94ef235cc6c7b
- this public replay commit: 7df6ea96993da7213683813a2e8f53d72a8c4ce0
- git range-diff reports the commits equal
- stable patch ID matches: 02b99e5e0fc8d404eebd13424d60890aa29a51d6
- targeted managed-key unit/CLI suite: 29 passed
- public full suite: 189 passed, 77 opt-in integration tests skipped
- public wheel and sdist build passed

## Required production gate
Production lifecycle e2e is intentionally not run yet because the plural runtime endpoints are not deployed. The test enforces prod target, cloud.morph.so, and MORPH_API_KEY-only auth. Keep this PR draft and do not merge, release, version bump, or deploy until the same production e2e passes here and in the private checkout.