### PR TITLE
Add progress bars to plugin install and update

### DIFF
--- a/morphcloud/plugins/cli.py
+++ b/morphcloud/plugins/cli.py
@@ -121,21 +121,28 @@ def plugin_install(
                 python_executable=target_python,
             )
             return
-        if entry.artifact_url:
-            plugin_installer.install_artifact(
-                entry.artifact_url,
-                upgrade=upgrade,
-                python_executable=target_python,
-            )
-        else:
-            plugin_installer.install_requirement(
-                target,
-                index_url=client.authenticated_simple_index_url(),
-                upgrade=upgrade,
-                python_executable=target_python,
-            )
-        if not skip_verify:
-            _verify_installed(entry, python_executable=target_python)
+        with click.progressbar(
+            length=1 if skip_verify else 2,
+            label=f"Installing plugin '{entry.name}'",
+            show_eta=False,
+        ) as progress:
+            if entry.artifact_url:
+                plugin_installer.install_artifact(
+                    entry.artifact_url,
+                    upgrade=upgrade,
+                    python_executable=target_python,
+                )
+            else:
+                plugin_installer.install_requirement(
+                    target,
+                    index_url=client.authenticated_simple_index_url(),
+                    upgrade=upgrade,
+                    python_executable=target_python,
+                )
+            progress.update(1)
+            if not skip_verify:
+                _verify_installed(entry, python_executable=target_python)
+                progress.update(1)
         click.echo(f"Installed plugin '{entry.name}' ({_redact_url(target)}).")
     except Exception as exc:
         _raise_click_error(exc)
@@ -226,21 +233,28 @@ def plugin_upgrade(
                 python_executable=target_python,
             )
             return
-        if entry.artifact_url:
-            plugin_installer.install_artifact(
-                entry.artifact_url,
-                upgrade=True,
-                python_executable=target_python,
-            )
-        else:
-            plugin_installer.install_requirement(
-                target,
-                index_url=client.authenticated_simple_index_url(),
-                upgrade=True,
-                python_executable=target_python,
-            )
-        if not skip_verify:
-            _verify_installed(entry, python_executable=target_python)
+        with click.progressbar(
+            length=1 if skip_verify else 2,
+            label=f"Upgrading plugin '{entry.name}'",
+            show_eta=False,
+        ) as progress:
+            if entry.artifact_url:
+                plugin_installer.install_artifact(
+                    entry.artifact_url,
+                    upgrade=True,
+                    python_executable=target_python,
+                )
+            else:
+                plugin_installer.install_requirement(
+                    target,
+                    index_url=client.authenticated_simple_index_url(),
+                    upgrade=True,
+                    python_executable=target_python,
+                )
+            progress.update(1)
+            if not skip_verify:
+                _verify_installed(entry, python_executable=target_python)
+                progress.update(1)
         click.echo(f"Upgraded plugin '{entry.name}' ({_redact_url(target)}).")
     except Exception as exc:
         _raise_click_error(exc)

--- a/tests/unit/test_cli_plugins.py
+++ b/tests/unit/test_cli_plugins.py
@@ -2,6 +2,7 @@ import json
 import types
 
 import click
+import pytest
 from click.testing import CliRunner
 
 from morphcloud import config
@@ -276,6 +277,55 @@ def test_plugin_install_uses_authenticated_index_and_verifies(monkeypatch):
         ("help", "intro", None),
     ]
     assert "secret" not in result.output
+
+
+@pytest.mark.parametrize(
+    ("command", "label"),
+    [
+        ("install", "Installing plugin 'intro'"),
+        ("update", "Upgrading plugin 'intro'"),
+    ],
+)
+def test_plugin_install_and_update_report_progress(monkeypatch, command, label):
+    import morphcloud.cli as cli_mod
+    import morphcloud.plugins.cli as plugin_cli
+
+    fake = FakeSimpleIndexClient()
+    _install_fake_client(monkeypatch, fake)
+    progress_updates = []
+
+    class FakeProgressBar:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return None
+
+        def update(self, amount):
+            progress_updates.append(amount)
+
+    monkeypatch.setattr(
+        plugin_cli.click,
+        "progressbar",
+        lambda *, length, label, show_eta: (
+            progress_updates.append((length, label, show_eta)) or FakeProgressBar()
+        ),
+    )
+    monkeypatch.setattr(
+        plugin_cli.plugin_installer,
+        "install_requirement",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(plugin_cli, "_verify_installed", lambda *args, **kwargs: None)
+
+    result = CliRunner().invoke(cli_mod.cli, ["plugin", command, "intro"])
+
+    assert result.exit_code == 0, result.output
+    assert progress_updates == [
+        (2, label, False),
+        1,
+        1,
+    ]
 
 
 def test_plugin_install_forwards_explicit_python_to_installer_and_verify(monkeypatch):


### PR DESCRIPTION
## Summary
- show progress while installing or updating plugins
- track package installation and post-install verification as separate steps
- cover both `plugin install` and the `plugin update` alias with focused tests

## Verification
- `uv run pytest -q tests/unit/test_cli_plugins.py tests/unit/test_plugin_installer.py`
- `uv run python -m compileall -q morphcloud/plugins`
- `git diff --check`